### PR TITLE
fix: get transaction by hash fullnode response type

### DIFF
--- a/crates/aptos-rust-sdk/src/client/rest_api.rs
+++ b/crates/aptos-rust-sdk/src/client/rest_api.rs
@@ -5,7 +5,7 @@ use aptos_rust_sdk_types::api_types::account::AccountResource;
 use aptos_rust_sdk_types::api_types::transaction::SignedTransaction;
 use aptos_rust_sdk_types::api_types::view::ViewRequest;
 use aptos_rust_sdk_types::mime_types::{
-    ACCEPT_BCS, BCS_SIGNED_TRANSACTION, BCS_VIEW_FUNCTION, JSON,
+    ACCEPT_BCS, BCS_SIGNED_TRANSACTION, JSON,
 };
 use aptos_rust_sdk_types::state::State;
 use aptos_rust_sdk_types::AptosResult;
@@ -39,7 +39,7 @@ impl AptosFullnodeClient {
     pub async fn get_transaction_by_hash(
         &self,
         hash: String,
-    ) -> AptosResult<FullnodeResponse<String>> {
+    ) -> AptosResult<FullnodeResponse<serde_json::Value>> {
         let url = self.build_rest_path(&format!("v1/transactions/by_hash/{}", hash))?;
         self.rest_get(url).await
     }
@@ -49,7 +49,7 @@ impl AptosFullnodeClient {
     pub async fn get_transaction_by_version(
         &self,
         version: u64,
-    ) -> AptosResult<FullnodeResponse<String>> {
+    ) -> AptosResult<FullnodeResponse<serde_json::Value>> {
         let url = self.build_rest_path(&format!("v1/transactions/by_version/{}", version))?;
         self.rest_get(url).await
     }

--- a/crates/aptos-rust-sdk/src/tests/client/rest_api.rs
+++ b/crates/aptos-rust-sdk/src/tests/client/rest_api.rs
@@ -16,7 +16,7 @@ async fn test_rest_client() {
 #[tokio::test]
 async fn test_get_by_version() {
     // TODO: Test against local testnet
-    let aptos_client = AptosFullnodeClient::builder(AptosNetwork::localnet()).build();
+    let aptos_client = AptosFullnodeClient::builder(AptosNetwork::testnet()).build();
 
     // Retrieve latest blockchain state
     let state = aptos_client
@@ -28,5 +28,17 @@ async fn test_get_by_version() {
     println!(
         "{:?}",
         aptos_client.get_transaction_by_version(state.version).await
+    );
+}
+
+#[tokio::test]
+async fn test_get_by_hash() {
+
+    let aptos_client = AptosFullnodeClient::builder(AptosNetwork::testnet()).build();
+
+    // Query transaction
+    println!(
+        "Full node response {:?}",
+        aptos_client.get_transaction_by_hash("0xd051f517d81f50e7b69a484bf6cea880c1a1f4a3e96cd5afdfd7a2e2a0cfc3b3".to_string()).await
     );
 }


### PR DESCRIPTION
API Response Fix
	•	Changed return type of get_transaction_by_hash and get_transaction_by_version in AptosFullnodeClient from
FullnodeResponse<String> → FullnodeResponse<serde_json::Value>.

Why?
The /transactions/* endpoints return a JSON object. Deserializing that into String blows up with:

JSON er/de error: invalid type: map, expected a string at line 1 column 0

After this patch you can inspect fields directly:

let tx = client.get_transaction_by_hash(hash).await?.into_inner();
println!("version = {}", tx["version"]);

