### PR TITLE
ci: harden GitHub Actions workflows (zizmor audit)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,27 @@
+name: Setup Rust
+description: Install Rust toolchain and configure cargo cache
+inputs:
+  toolchain:
+    description: Rust toolchain version (e.g. stable, nightly, "1.90")
+    required: false
+    default: stable
+  components:
+    description: Additional components (e.g. rustfmt, clippy)
+    required: false
+    default: ''
+  cache:
+    description: Enable cargo caching via Swatinem/rust-cache
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Install Rust ${{ inputs.toolchain }}
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+
+    - name: Cache cargo
+      if: inputs.cache == 'true'
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,83 +14,87 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
           components: rustfmt
-      
+          cache: 'false'
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
           components: clippy
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Run Clippy (default features)
         run: cargo clippy -p aptos-sdk --all-targets -- -D warnings
-      
+
       - name: Run Clippy (all features)
         run: cargo clippy -p aptos-sdk --all-targets --all-features -- -D warnings
-      
+
       - name: Run Clippy (no default features)
         run: cargo clippy -p aptos-sdk --no-default-features -- -D warnings
 
   test:
     name: Test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust ${{ matrix.rust }}
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: ${{ matrix.rust }}
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Build
         run: cargo build -p aptos-sdk --all-targets
-      
+
       - name: Run tests
         run: cargo test -p aptos-sdk --all-targets
-      
+
       - name: Run tests (all features)
         run: cargo test -p aptos-sdk --all-targets --all-features
 
   test-linux-arm:
     name: Test (Linux ARM64)
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build -p aptos-sdk --all-targets
@@ -104,16 +108,16 @@ jobs:
   test-macos-intel:
     name: Test (macOS x86)
     runs-on: macos-15-intel
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build -p aptos-sdk --all-targets
@@ -127,6 +131,8 @@ jobs:
   test-no-simd:
     name: Test (Linux No SIMD - Docker Compatible)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       # Disable BLST assembly optimizations for portability
       BLST_PORTABLE: "1"
@@ -135,15 +141,13 @@ jobs:
       # QEMU x86 emulation, where advanced SIMD instructions are unavailable.
       RUSTFLAGS: "-C target-cpu=x86-64"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: stable
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Build (default features)
         run: cargo build -p aptos-sdk --all-targets
@@ -160,35 +164,35 @@ jobs:
   test-features:
     name: Test Feature Combinations
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Test with only ed25519
         run: cargo test -p aptos-sdk --no-default-features --features ed25519
-      
+
       - name: Test with only secp256k1
         run: cargo test -p aptos-sdk --no-default-features --features secp256k1
-      
+
       - name: Test with secp256r1
         run: cargo test -p aptos-sdk --features secp256r1
-      
+
       - name: Test with bls
         run: cargo test -p aptos-sdk --features bls
-      
+
       - name: Test with faucet
         run: cargo test -p aptos-sdk --features faucet
-      
+
       - name: Test with indexer
         run: cargo test -p aptos-sdk --features indexer
-      
+
       - name: Test with full features
         run: cargo test -p aptos-sdk --features full
 
@@ -198,14 +202,14 @@ jobs:
   #   name: Spec Tests
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v6
-  #     
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+  #
   #     - name: Install Rust
   #       uses: dtolnay/rust-toolchain@stable
-  #     
+  #
   #     - name: Cache cargo
-  #       uses: Swatinem/rust-cache@v2
-  #     
+  #       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+  #
   #     - name: Run spec tests
   #       run: cargo test --test specs
   #       working-directory: specifications/tests/rust
@@ -213,20 +217,22 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust nightly (required for doc_auto_cfg and docs.rs parity)
-        uses: dtolnay/rust-toolchain@nightly
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
+
       - name: Check documentation (docs.rs parity)
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings
         run: cargo +nightly doc -p aptos-sdk --no-deps --all-features
-      
+
       - name: Check macros documentation
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings
@@ -246,76 +252,76 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust nightly (required for doc_auto_cfg feature)
-        uses: dtolnay/rust-toolchain@nightly
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
+
       - name: Build documentation
         env:
           RUSTDOCFLAGS: --cfg docsrs
         run: cargo +nightly doc -p aptos-sdk --no-deps --all-features
-      
+
       - name: Add redirect to main crate
         run: |
           echo '<meta http-equiv="refresh" content="0; url=aptos_sdk/index.html">' > target/doc/index.html
-      
+
       - name: Setup Pages
-        uses: actions/configure-pages@v5
-      
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: target/doc
-      
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
   msrv:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust 1.85
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.85"
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Check MSRV
         run: cargo check -p aptos-sdk
 
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
-      
+
       - name: Run coverage
         run: |
           cargo tarpaulin -p aptos-sdk --features "full" --skip-clean --out Xml --out Html --output-dir target/coverage
         working-directory: crates/aptos-sdk
-      
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: crates/aptos-sdk/target/coverage/cobertura.xml
@@ -327,11 +333,15 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
       - name: Install cargo-audit
         run: cargo install cargo-audit
-      
+
       - name: Run security audit
         run: cargo audit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,17 +18,17 @@ jobs:
   e2e-localnet:
     name: E2E Tests (Localnet)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Aptos CLI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
   resolve:
     name: Resolve Crates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       publish_macros: ${{ steps.resolve.outputs.publish_macros }}
       publish_sdk: ${{ steps.resolve.outputs.publish_sdk }}
@@ -67,30 +69,32 @@ jobs:
   verify:
     name: Verify Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      
-      - name: Install Rust nightly (for docs.rs parity check)
-        uses: dtolnay/rust-toolchain@nightly
-      
-      - name: Install Rust stable (primary toolchain)
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
+          cache: 'false'
+
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
           components: clippy, rustfmt
-      
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      
+
       - name: Check formatting
         run: cargo fmt --all -- --check
-      
+
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-      
+
       - name: Run tests
         run: cargo test --all-targets --all-features
-      
+
       - name: Build documentation (docs.rs parity)
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings
@@ -99,18 +103,18 @@ jobs:
   publish-macros:
     name: Publish aptos-sdk-macros
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [resolve, verify]
     if: needs.resolve.outputs.publish_macros == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       # --no-verify: The aptos-sdk dev-dependency is path-only (dropped from the
       # published crate to break the circular publish dependency), so the
@@ -129,6 +133,8 @@ jobs:
   publish-sdk:
     name: Publish aptos-sdk
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [resolve, verify, publish-macros]
     # Run if SDK should be published, AND either macros wasn't needed or macros succeeded
     if: |
@@ -137,15 +143,13 @@ jobs:
       needs.verify.result == 'success' &&
       (needs.publish-macros.result == 'success' || needs.publish-macros.result == 'skipped')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/setup-rust
         with:
           toolchain: "1.90"
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       # If macros was just published, poll crates.io until it's indexed
       - name: Wait for crates.io to index aptos-sdk-macros
@@ -204,12 +208,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      
+          persist-credentials: false
+
       - name: Generate release notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           draft: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,11 +17,16 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache: 'false'
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -33,11 +38,16 @@ jobs:
   deny:
     name: Dependency Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache: 'false'
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked


### PR DESCRIPTION
## Summary

Security hardening of GitHub Actions workflows based on a zizmor static analysis audit of the aptos-labs org (80 findings across 4 workflow files).

## Changes

| Rule | Count | Fix applied |
|---|---|---|
| `unpinned-uses` | 57 | Pinned all mutable action refs to commit SHAs; tag immutability verified via GitHub rulesets API (no active `deletion`/`non_fast_forward` rules found on any flagged repo) |
| `excessive-permissions` | 21 | Added scoped `permissions:` block to every job (`contents: read` minimum; `deploy-docs` retains `pages: write` + `id-token: write`; `release-notes` retains `contents: write`) |
| `artipacked` | — | Added `persist-credentials: false` to all `actions/checkout` steps (suppresses git-credential store on runner disk) |
| `cache-poisoning` | 3 | Resolved by pinning `actions/checkout` and `Swatinem/rust-cache` to SHAs in the affected `release.yml` jobs |

## Tag immutability verification

Each flagged action repo was queried via `gh api repos/OWNER/REPO/rulesets`. No active `deletion` or `non_fast_forward` rulesets were found on any repo (`actions/*` orgs only have a "Copilot Code Review" branch ruleset; third-party repos returned `false`). All tags are therefore mutable and have been replaced with commit SHAs.

## SHA pin map

| Action | Tag/ref | Pinned SHA |
|---|---|---|
| `actions/checkout` | `v6` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/configure-pages` | `v5` | `983d7736d9b0ae728b81ab479565c72886d7745b` |
| `actions/deploy-pages` | `v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` |
| `actions/upload-pages-artifact` | `v4` | `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` |
| `codecov/codecov-action` | `v5` | `75cd11691c0faa626561e295848008c8a7dddffe` |
| `dtolnay/rust-toolchain` | `master` | `3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9` |
| `dtolnay/rust-toolchain` | `nightly` | `5b842231ba77f5c045dba54ac5560fed2db780e2` |
| `dtolnay/rust-toolchain` | `stable` | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
| `softprops/action-gh-release` | `v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |
| `Swatinem/rust-cache` | `v2` | `e18b497796c12c097a38f9edb9d0641fb99eee32` |

## Test plan

- [ ] All 4 YAML files parse without errors (`python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`)
- [ ] CI passes on this branch (format, lint, test, docs jobs)
- [ ] No remaining zizmor findings at `error` severity on these files
- [ ] `deploy-docs` job still deploys pages successfully on next `main` push
- [ ] `release-notes` job still has `contents: write` permission to create GitHub releases