### PR TITLE
chore(deps): bump rand from 0.8.5 to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "p256",
  "proptest",
  "proptest-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_bytes",
@@ -225,7 +225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -1646,9 +1646,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the locked version of `rand` from `0.8.5` to `0.8.6` (the newest patch in the 0.8 line, published 2026-04-17).

The workspace `Cargo.toml` already pins `rand = "0.8"`, which is SemVer-compatible with 0.8.6, so this is a **lockfile-only** change — no manifest changes, and no source changes are required.

## Why 0.8 (and not 0.9 / 0.10)?

The comment in `crates/aptos-sdk/Cargo.toml` notes that we keep `rand` on the 0.8 line so it stays compatible with `ed25519-dalek` and `k256`, which still depend on `rand_core` 0.6. Bumping to 0.9 / 0.10 would require coordinating with those upstream crates and is out of scope here. This PR just picks up the latest patch on the line we already track.

## Changelog

`rand` is an internal dependency and is not re-exported from the public SDK surface (verified — no `pub use rand` / `pub mod rand` / `extern crate rand` anywhere in the crate). Per `AGENTS.md`, internal dep bumps with no observable effect do not need a changelog entry.

## Verification

Ran the full required workflow from `AGENTS.md` locally on Linux x86_64 with the pinned 1.95 toolchain:

- `cargo fmt -- --check` — clean
- `cargo clippy -p aptos-sdk --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p aptos-sdk --all-targets -- -D warnings` (default features) — clean
- `cargo clippy -p aptos-sdk --no-default-features -- -D warnings` — clean
- `cargo test -p aptos-sdk --all-features` — **978 tests pass, 0 failed** (895 unit + 51 behavioral + 32 doctests; the 79 ignored tests are the `#[ignore]`d e2e suite)
- `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc -p aptos-sdk --all-features --no-deps` — clean

## Diff

```text
 Cargo.lock | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```

Three lockfile entries are touched: the `rand` package itself, and the two reverse-dependency entries (`aptos-sdk`, `bip39`) that record `rand 0.8.5 → 0.8.6`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2421e94a-c0a4-427e-89fe-74647aaae1c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2421e94a-c0a4-427e-89fe-74647aaae1c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

