### PR TITLE
feat: audit follow-ups — mnemonic Secp256k1, pagination, wire-format fixtures, ANS scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,9 @@ point:
   - `fullnode.rs` -- REST API client for fullnode interactions.
   - `indexer.rs` -- GraphQL indexer client.
   - `faucet.rs` -- faucet client for testnets / devnet.
-  - `ans.rs` -- Aptos Names Service integration.
+  - `ans.rs` -- Aptos Names Service client. **Scaffold only**: all
+    methods currently return `AptosError::Internal("not yet implemented")`.
+    Tracked as an audit follow-up; see the module docs for design notes.
 - **`transaction/`** -- transaction building and signing.
   - `builder.rs` -- fluent builder pattern.
   - `authenticator.rs` -- `TransactionAuthenticator` and

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
+- `api::AnsClient` scaffold (`api/ans.rs`) -- exposes `lookup(name)` and
+  `reverse_lookup(address)` method signatures so future ANS work has an
+  obvious landing spot. Both methods currently return
+  `AptosError::Internal("...not yet implemented...")` so callers fail
+  fast rather than silently treating placeholder addresses as real.
+  Reconciles the previous `AGENTS.md` reference to `api/ans.rs` with
+  reality (the file did not exist before this commit).
 - New behavioral test module `tests/behavioral/wire_format.rs` -- pins the
   exact BCS / signing-message byte layout for `RawTransaction` (sequenced
   and orderless prefixes), `AccountAuthenticator::Ed25519`,

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -200,6 +200,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alignment improves domain separation from other ECDSA-over-SHA-256
   protocols; `Aptos::simulate` no longer routes private-key material
   through the gas-estimation path).
+- BIP-32 secp256k1 derivation now zeroizes the per-step HMAC input buffer
+  for hardened components, which transiently contains the parent private
+  key (`0x00 || ser_256(k_par) || ser_32(i)`). Previously that buffer
+  was dropped without scrubbing, leaving secret material on the heap
+  until reused.
+- Documented the deliberate deviation from BIP-32's "advance to index
+  i+1" retry rule when an intermediate `I_L` is `>= n` or the derived
+  child scalar is `0`. We return an error instead of silently producing
+  a key at a different path; the failure probability per component is
+  ~2^-127.
 - Hardened MultiKey decoding: `MultiKeyPublicKey`, `MultiKeySignature`, `AnyPublicKey`, and `AnySignature` now enforce bounded element counts and exact key/signature length checks during deserialization to reduce memory-amplification DoS risk.
 - Hardened authenticator address checks: multi-agent and fee-payer verification now enforces sender, secondary signer, and fee payer derived-address consistency.
 - Keyless variants continue to be rejected from MultiKey-only decoding paths (`AnyPublicKey` / `AnySignature`) where they are not valid inputs.

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
+- New behavioral test module `tests/behavioral/wire_format.rs` -- pins the
+  exact BCS / signing-message byte layout for `RawTransaction` (sequenced
+  and orderless prefixes), `AccountAuthenticator::Ed25519`,
+  `AccountAuthenticator::SingleKey(AnyPublicKey::Ed25519)`, and a nested
+  generic `TypeTag`. Inputs are fully deterministic (fixed Ed25519 key,
+  fixed expiration, fixed nonce) so the resulting bytes can be cross-checked
+  against the TypeScript SDK constructed with identical inputs.
 - `FullnodeClient::get_account_resources_paginated(address, start, limit)`
   and `FullnodeClient::get_account_modules_paginated(address, start, limit)`
   -- forward `start` / `limit` query parameters to the REST API so callers

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reality (the file did not exist before this commit).
 - New behavioral test module `tests/behavioral/wire_format.rs` -- pins the
   exact BCS / signing-message byte layout for `RawTransaction` (sequenced
-  and orderless prefixes), `AccountAuthenticator::Ed25519`,
-  `AccountAuthenticator::SingleKey(AnyPublicKey::Ed25519)`, and a nested
-  generic `TypeTag`. Inputs are fully deterministic (fixed Ed25519 key,
-  fixed expiration, fixed nonce) so the resulting bytes can be cross-checked
-  against the TypeScript SDK constructed with identical inputs.
+  full-hex pin and orderless prefix), `AccountAuthenticator::Ed25519`,
+  `AccountAuthenticator::SingleKey(AnyPublicKey::Ed25519)`,
+  `AccountAuthenticator::MultiEd25519` (variant 1, with bitmap layout),
+  `AccountAuthenticator::MultiKey` (variant 3, mixed Ed25519+Secp256k1
+  with BitVec bitmap), and a nested generic `TypeTag`. Inputs are fully
+  deterministic (fixed Ed25519 / Secp256k1 keys, fixed expiration, fixed
+  nonce) so the resulting bytes can be cross-checked against the
+  TypeScript SDK constructed with identical inputs.
 - `FullnodeClient::get_account_resources_paginated(address, start, limit)`
   and `FullnodeClient::get_account_modules_paginated(address, start, limit)`
   -- forward `start` / `limit` query parameters to the REST API so callers

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
+- `account::DerivationPath` (and its `PathComponent`) — parses BIP-32 / BIP-44
+  derivation path strings (`m/44'/637'/0'/0/0`, lowercase `h` also accepted as
+  a hardened marker) and exposes `aptos_ed25519(idx)` / `aptos_secp256k1(idx)`
+  for the canonical Aptos paths. The Ed25519 default is fully hardened
+  (`m/44'/637'/x'/0'/0'`); the Secp256k1 default uses the BIP-44 mixed form
+  (`m/44'/637'/x'/0/0`) to match the TypeScript SDK's `APTOS_BIP44_REGEX`.
+- `Mnemonic::derive_secp256k1_key(index)` — derives an Aptos Secp256k1 private
+  key via BIP-32 along the canonical Aptos path. Cross-validated against the
+  Bitcoin reference vector for the `abandon × 11 about` mnemonic at
+  `m/44'/0'/0'/0/0` so hardened + non-hardened child derivation are both
+  exercised by tests.
+- `Mnemonic::derive_ed25519_key_at_path(&path)` and
+  `Mnemonic::derive_secp256k1_key_at_path(&path)` — derive at a caller-supplied
+  derivation path. Ed25519 paths must be fully hardened (SLIP-0010) and a
+  non-hardened component returns `AptosError::KeyDerivation` instead of
+  producing an invalid key.
 - `FullnodeClient::simulate_transaction_with_options` — simulate with optional query parameters (`estimate_max_gas_amount`, `estimate_gas_unit_price`, `estimate_prioritized_gas_unit_price`). Existing `simulate_transaction` is unchanged (single-arg) and delegates to the new method with `None` for backward compatibility.
 - `Aptos::simulate_signed_with_options`, plus option-aware multi-signer simulation (`Aptos::simulate_multi_agent`, `Aptos::simulate_fee_payer`) for consistent high-level simulation APIs while preserving no-options usage.
 - `build_simulation_signed_multi_agent` and `build_simulation_signed_fee_payer` for constructing simulation-only signed transactions using `NoAccountAuthenticator` placeholders.

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -29,15 +29,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `FullnodeClient::get_account_modules_paginated(address, start, limit)`
   -- forward `start` / `limit` query parameters to the REST API so callers
   can page through accounts that publish more resources / modules than the
-  default page size. The previous one-shot `get_account_resources` /
+  default page size. `start` is `Option<&str>` so opaque cursor tokens
+  surfaced through the `x-aptos-cursor` header (`AptosResponse::cursor`)
+  round-trip losslessly. The previous one-shot `get_account_resources` /
   `get_account_modules` methods are preserved and delegate to the new
   pagination methods with `None` for both arguments.
-- `account::DerivationPath` (and its `PathComponent`) — parses BIP-32 / BIP-44
-  derivation path strings (`m/44'/637'/0'/0/0`, lowercase `h` also accepted as
-  a hardened marker) and exposes `aptos_ed25519(idx)` / `aptos_secp256k1(idx)`
-  for the canonical Aptos paths. The Ed25519 default is fully hardened
-  (`m/44'/637'/x'/0'/0'`); the Secp256k1 default uses the BIP-44 mixed form
-  (`m/44'/637'/x'/0/0`) to match the TypeScript SDK's `APTOS_BIP44_REGEX`.
+- `account::DerivationPath` and `account::PathComponent` -- parse BIP-32 /
+  BIP-44 derivation path strings (`m/44'/637'/0'/0/0`, lowercase `h` also
+  accepted as a hardened marker) and expose
+  `aptos_ed25519(address_index) -> AptosResult<Self>` /
+  `aptos_secp256k1(address_index) -> AptosResult<Self>` builders for the
+  canonical Aptos paths. `address_index` lives in the BIP-44 5th
+  component to match the pre-existing `Mnemonic::derive_ed25519_key`
+  behavior; callers needing TS-SDK-style account-level indexing must
+  build the path explicitly via `DerivationPath::from_str`.
+  `PathComponent` fields are private; construct via
+  `PathComponent::try_new(index, hardened)` which rejects `index >= 2^31`
+  (the BIP-32 hardened bit).
 - `Mnemonic::derive_secp256k1_key(index)` — derives an Aptos Secp256k1 private
   key via BIP-32 along the canonical Aptos path. Cross-validated against the
   Bitcoin reference vector for the `abandon × 11 about` mnemonic at

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Added
+- `FullnodeClient::get_account_resources_paginated(address, start, limit)`
+  and `FullnodeClient::get_account_modules_paginated(address, start, limit)`
+  -- forward `start` / `limit` query parameters to the REST API so callers
+  can page through accounts that publish more resources / modules than the
+  default page size. The previous one-shot `get_account_resources` /
+  `get_account_modules` methods are preserved and delegate to the new
+  pagination methods with `None` for both arguments.
 - `account::DerivationPath` (and its `PathComponent`) — parses BIP-32 / BIP-44
   derivation path strings (`m/44'/637'/0'/0/0`, lowercase `h` also accepted as
   a hardened marker) and exposes `aptos_ed25519(idx)` / `aptos_secp256k1(idx)`

--- a/crates/aptos-sdk/src/account/mnemonic.rs
+++ b/crates/aptos-sdk/src/account/mnemonic.rs
@@ -5,17 +5,20 @@
 //! # Supported curves
 //!
 //! - **Ed25519** uses SLIP-0010 with the Aptos default path
-//!   `m/44'/637'/{account}'/{change}'/{address}'`. Every component MUST be
-//!   hardened because Ed25519 does not admit non-hardened child derivation
-//!   (no scalar homomorphism on Curve25519). The `from_str` parser will
-//!   reject non-hardened components when the resulting path is used with
-//!   Ed25519.
+//!   `m/44'/637'/0'/0'/{address_index}'`. Every component MUST be hardened
+//!   because Ed25519 does not admit non-hardened child derivation (no
+//!   scalar homomorphism on Curve25519). The `from_str` parser will reject
+//!   non-hardened components when the resulting path is used with Ed25519.
 //! - **Secp256k1** uses BIP-32 with the Aptos default path
-//!   `m/44'/637'/{account}'/0/0` -- the last two indices are non-hardened
-//!   to match the official TypeScript SDK (`isValidBIP44Path`).
+//!   `m/44'/637'/0'/0/{address_index}` -- the last two indices are
+//!   non-hardened, matching the TypeScript SDK's `APTOS_BIP44_REGEX`.
 //!
-//! Custom paths can be supplied via [`DerivationPath::from_str`] for both
-//! curves.
+//! `derive_ed25519_key(index)` and `derive_secp256k1_key(index)` place
+//! `index` in the **5th (address) component**, preserving the pre-PR Rust
+//! SDK semantics so existing addresses derived from a mnemonic do not
+//! shift between SDK versions. Callers needing to vary the BIP-44
+//! **account** index (the Petra / TS-SDK convention) should build the
+//! path explicitly via [`DerivationPath::from_str`].
 
 use crate::error::{AptosError, AptosResult};
 
@@ -30,16 +33,52 @@ const APTOS_COIN_TYPE: u32 = 637;
 ///
 /// Wraps a 31-bit numeric index plus a hardened flag. The encoded 32-bit
 /// value used during derivation is `index | 0x80000000` when hardened.
+///
+/// Fields are private to enforce the `index < 2^31` invariant: a value with
+/// the hardened bit already set would collide with an explicitly hardened
+/// component during BIP-32 derivation, producing an ambiguous key. Use
+/// [`Self::try_new`] to construct.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PathComponent {
     /// The 31-bit numeric index (without the hardened bit applied).
-    pub index: u32,
+    index: u32,
     /// Whether this component is hardened (denoted by a trailing apostrophe
     /// in path strings, e.g. `44'`).
-    pub hardened: bool,
+    hardened: bool,
 }
 
 impl PathComponent {
+    /// Constructs a path component, rejecting any `index` whose top bit is
+    /// set (i.e. `index >= 2^31 = 0x8000_0000`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AptosError::KeyDerivation`] if `index` has its hardened
+    /// bit set; valid BIP-32 indices are confined to 31 bits and the
+    /// hardened bit is supplied via the `hardened` flag.
+    pub fn try_new(index: u32, hardened: bool) -> AptosResult<Self> {
+        if index & HARDENED_OFFSET != 0 {
+            return Err(AptosError::KeyDerivation(format!(
+                "derivation index {index} exceeds 2^31 - 1; the hardened bit \
+                 must come from the `hardened` flag, not the raw value"
+            )));
+        }
+        Ok(Self { index, hardened })
+    }
+
+    /// Returns the 31-bit numeric index without the hardened bit applied.
+    #[must_use]
+    pub fn index(self) -> u32 {
+        self.index
+    }
+
+    /// Returns `true` when this component is hardened (encoded as
+    /// `index | 0x80000000` during derivation).
+    #[must_use]
+    pub fn hardened(self) -> bool {
+        self.hardened
+    }
+
     /// Encodes this component as the 32-bit value passed to BIP-32 / SLIP-0010
     /// child-key derivation (i.e. with the hardened bit set when applicable).
     #[must_use]
@@ -74,73 +113,63 @@ impl DerivationPath {
     /// Ed25519 derivation rejects paths that are not fully hardened.
     #[must_use]
     pub fn is_fully_hardened(&self) -> bool {
-        self.components.iter().all(|c| c.hardened)
+        self.components.iter().all(|c| c.hardened())
     }
 
     /// Builds the canonical Aptos Ed25519 derivation path
-    /// `m/44'/637'/{account_index}'/0'/0'`.
+    /// `m/44'/637'/0'/0'/{address_index}'`.
     ///
-    /// This matches the TypeScript SDK's `APTOS_HARDENED_REGEX`.
-    #[must_use]
-    pub fn aptos_ed25519(account_index: u32) -> Self {
-        Self {
+    /// The `address_index` is placed in the final (address) BIP-44 component
+    /// for backward compatibility with the pre-existing
+    /// `Mnemonic::derive_ed25519_key(index)` behavior. Callers needing to
+    /// vary the BIP-44 *account* index (the Petra/TS-SDK convention) should
+    /// construct the path explicitly via [`Self::from_str`] and pass it to
+    /// [`Mnemonic::derive_ed25519_key_at_path`].
+    ///
+    /// All five components are hardened, matching the TypeScript SDK's
+    /// `APTOS_HARDENED_REGEX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AptosError::KeyDerivation`] if `address_index >= 2^31`
+    /// (the top bit is reserved as the BIP-32 hardened flag).
+    pub fn aptos_ed25519(address_index: u32) -> AptosResult<Self> {
+        let h = |i| PathComponent::try_new(i, true);
+        Ok(Self {
             components: vec![
-                PathComponent {
-                    index: BIP44_PURPOSE,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: APTOS_COIN_TYPE,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: account_index,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: 0,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: 0,
-                    hardened: true,
-                },
+                h(BIP44_PURPOSE)?,
+                h(APTOS_COIN_TYPE)?,
+                h(0)?,
+                h(0)?,
+                h(address_index)?,
             ],
-        }
+        })
     }
 
     /// Builds the canonical Aptos Secp256k1 derivation path
-    /// `m/44'/637'/{account_index}'/0/0`.
+    /// `m/44'/637'/0'/0/{address_index}`.
     ///
-    /// The last two indices are intentionally **not** hardened, matching the
-    /// TypeScript SDK's `APTOS_BIP44_REGEX`. Hardened paths are also valid
-    /// for Secp256k1 but the Aptos default uses the mixed form.
-    #[must_use]
-    pub fn aptos_secp256k1(account_index: u32) -> Self {
-        Self {
+    /// The `address_index` is placed in the final (address) BIP-44 component
+    /// for symmetry with [`Self::aptos_ed25519`]. The last two indices are
+    /// non-hardened, matching the TypeScript SDK's `APTOS_BIP44_REGEX`.
+    /// Callers needing to vary the BIP-44 *account* index should construct
+    /// the path explicitly via [`Self::from_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AptosError::KeyDerivation`] if `address_index >= 2^31`.
+    pub fn aptos_secp256k1(address_index: u32) -> AptosResult<Self> {
+        let h = |i| PathComponent::try_new(i, true);
+        let u = |i| PathComponent::try_new(i, false);
+        Ok(Self {
             components: vec![
-                PathComponent {
-                    index: BIP44_PURPOSE,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: APTOS_COIN_TYPE,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: account_index,
-                    hardened: true,
-                },
-                PathComponent {
-                    index: 0,
-                    hardened: false,
-                },
-                PathComponent {
-                    index: 0,
-                    hardened: false,
-                },
+                h(BIP44_PURPOSE)?,
+                h(APTOS_COIN_TYPE)?,
+                h(0)?,
+                u(0)?,
+                u(address_index)?,
             ],
-        }
+        })
     }
 
     /// Parses a derivation path of the form `m/44'/637'/0'/0'/0'`.
@@ -197,13 +226,14 @@ impl std::str::FromStr for DerivationPath {
                 ))
             })?;
 
-            if index & HARDENED_OFFSET != 0 {
-                return Err(AptosError::KeyDerivation(format!(
-                    "derivation index {index} exceeds 2^31 - 1 in path: {path}"
-                )));
-            }
-
-            components.push(PathComponent { index, hardened });
+            components.push(
+                PathComponent::try_new(index, hardened).map_err(|e| match e {
+                    AptosError::KeyDerivation(msg) => {
+                        AptosError::KeyDerivation(format!("{msg} in path: {path}"))
+                    }
+                    other => other,
+                })?,
+            );
         }
 
         if components.is_empty() {
@@ -220,10 +250,10 @@ impl std::fmt::Display for DerivationPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("m")?;
         for c in &self.components {
-            if c.hardened {
-                write!(f, "/{}'", c.index)?;
+            if c.hardened() {
+                write!(f, "/{}'", c.index())?;
             } else {
-                write!(f, "/{}", c.index)?;
+                write!(f, "/{}", c.index())?;
             }
         }
         Ok(())
@@ -346,7 +376,7 @@ impl Mnemonic {
     /// Returns an error if key derivation fails or the derived key is invalid.
     #[cfg(feature = "ed25519")]
     pub fn derive_ed25519_key(&self, index: u32) -> AptosResult<crate::crypto::Ed25519PrivateKey> {
-        self.derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(index))
+        self.derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(index)?)
     }
 
     /// Derives an Ed25519 private key at a custom BIP-44 path.
@@ -396,7 +426,7 @@ impl Mnemonic {
         &self,
         index: u32,
     ) -> AptosResult<crate::crypto::Secp256k1PrivateKey> {
-        self.derive_secp256k1_key_at_path(&DerivationPath::aptos_secp256k1(index))
+        self.derive_secp256k1_key_at_path(&DerivationPath::aptos_secp256k1(index)?)
     }
 
     /// Derives a Secp256k1 private key at a custom BIP-32 path.
@@ -496,7 +526,7 @@ fn derive_secp256k1_at_path(seed: &[u8], path: &DerivationPath) -> AptosResult<[
 
     for component in path.components() {
         let encoded = component.encoded();
-        let data = if component.hardened {
+        let data = if component.hardened() {
             // 0x00 || ser_256(k_par) || ser_32(i)
             let mut buf = Vec::with_capacity(1 + 32 + 4);
             buf.push(0u8);
@@ -636,18 +666,34 @@ mod tests {
 
     #[test]
     fn test_aptos_default_paths() {
+        // `address_index` lives in the 5th BIP-44 component, matching the
+        // pre-PR `derive_ed25519_key(index)` behavior so existing addresses
+        // derived from a mnemonic do not silently shift between SDK versions.
         assert_eq!(
-            DerivationPath::aptos_ed25519(0).to_string(),
+            DerivationPath::aptos_ed25519(0).unwrap().to_string(),
             "m/44'/637'/0'/0'/0'"
         );
         assert_eq!(
-            DerivationPath::aptos_secp256k1(0).to_string(),
+            DerivationPath::aptos_secp256k1(0).unwrap().to_string(),
             "m/44'/637'/0'/0/0"
         );
         assert_eq!(
-            DerivationPath::aptos_ed25519(5).to_string(),
-            "m/44'/637'/5'/0'/0'"
+            DerivationPath::aptos_ed25519(5).unwrap().to_string(),
+            "m/44'/637'/0'/0'/5'",
+            "address_index belongs in the 5th component",
         );
+        assert_eq!(
+            DerivationPath::aptos_secp256k1(5).unwrap().to_string(),
+            "m/44'/637'/0'/0/5",
+            "address_index belongs in the 5th component (non-hardened)",
+        );
+    }
+
+    #[test]
+    fn test_aptos_default_paths_reject_oversize_index() {
+        // The 31-bit invariant surfaces as an error rather than panicking.
+        assert!(DerivationPath::aptos_ed25519(0x8000_0000).is_err());
+        assert!(DerivationPath::aptos_secp256k1(0x8000_0000).is_err());
     }
 
     #[test]
@@ -678,7 +724,7 @@ mod tests {
         let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
         let via_index = mnemonic.derive_ed25519_key(3).unwrap();
         let via_path = mnemonic
-            .derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(3))
+            .derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(3).unwrap())
             .unwrap();
         assert_eq!(via_index.to_bytes(), via_path.to_bytes());
     }
@@ -732,16 +778,25 @@ mod tests {
 
     #[test]
     fn test_path_component_encoded_sets_hardened_bit() {
-        let hardened = PathComponent {
-            index: 44,
-            hardened: true,
-        };
-        let unhardened = PathComponent {
-            index: 44,
-            hardened: false,
-        };
+        let hardened = PathComponent::try_new(44, true).unwrap();
+        let unhardened = PathComponent::try_new(44, false).unwrap();
         assert_eq!(hardened.encoded(), 0x8000_002C);
         assert_eq!(unhardened.encoded(), 44);
+        assert_eq!(hardened.index(), 44);
+        assert!(hardened.hardened());
+        assert!(!unhardened.hardened());
+    }
+
+    #[test]
+    fn test_path_component_rejects_oversize_index() {
+        // Top bit reserved as the hardened flag in BIP-32; raw values
+        // with that bit already set would collide with hardened components
+        // and produce ambiguous derivations. `try_new` MUST reject them.
+        assert!(PathComponent::try_new(0x8000_0000, false).is_err());
+        assert!(PathComponent::try_new(0x8000_0000, true).is_err());
+        assert!(PathComponent::try_new(0xFFFF_FFFF, false).is_err());
+        // Boundary: 2^31 - 1 is the largest valid raw index.
+        assert!(PathComponent::try_new(0x7FFF_FFFF, true).is_ok());
     }
 
     #[test]

--- a/crates/aptos-sdk/src/account/mnemonic.rs
+++ b/crates/aptos-sdk/src/account/mnemonic.rs
@@ -1,8 +1,234 @@
 //! BIP-39 mnemonic phrase support for key derivation.
 //!
 //! This module requires the `mnemonic` feature flag.
+//!
+//! # Supported curves
+//!
+//! - **Ed25519** uses SLIP-0010 with the Aptos default path
+//!   `m/44'/637'/{account}'/{change}'/{address}'`. Every component MUST be
+//!   hardened because Ed25519 does not admit non-hardened child derivation
+//!   (no scalar homomorphism on Curve25519). The `from_str` parser will
+//!   reject non-hardened components when the resulting path is used with
+//!   Ed25519.
+//! - **Secp256k1** uses BIP-32 with the Aptos default path
+//!   `m/44'/637'/{account}'/0/0` -- the last two indices are non-hardened
+//!   to match the official TypeScript SDK (`isValidBIP44Path`).
+//!
+//! Custom paths can be supplied via [`DerivationPath::from_str`] for both
+//! curves.
 
 use crate::error::{AptosError, AptosResult};
+
+/// Hardened-bit offset used by BIP-32 / SLIP-0010 to flag a hardened index.
+const HARDENED_OFFSET: u32 = 0x8000_0000;
+/// BIP-44 purpose (`44'`).
+const BIP44_PURPOSE: u32 = 44;
+/// Aptos coin type (`637'`).
+const APTOS_COIN_TYPE: u32 = 637;
+
+/// A single component of a BIP-32 derivation path.
+///
+/// Wraps a 31-bit numeric index plus a hardened flag. The encoded 32-bit
+/// value used during derivation is `index | 0x80000000` when hardened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PathComponent {
+    /// The 31-bit numeric index (without the hardened bit applied).
+    pub index: u32,
+    /// Whether this component is hardened (denoted by a trailing apostrophe
+    /// in path strings, e.g. `44'`).
+    pub hardened: bool,
+}
+
+impl PathComponent {
+    /// Encodes this component as the 32-bit value passed to BIP-32 / SLIP-0010
+    /// child-key derivation (i.e. with the hardened bit set when applicable).
+    #[must_use]
+    pub fn encoded(self) -> u32 {
+        if self.hardened {
+            self.index | HARDENED_OFFSET
+        } else {
+            self.index
+        }
+    }
+}
+
+/// A parsed BIP-32 / BIP-44 derivation path.
+///
+/// Use [`Self::aptos_ed25519`] / [`Self::aptos_secp256k1`] for the canonical
+/// Aptos paths, or [`Self::from_str`] to parse a custom path of the form
+/// `m/44'/637'/0'/0'/0'`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DerivationPath {
+    components: Vec<PathComponent>,
+}
+
+impl DerivationPath {
+    /// Returns the path components in order.
+    #[must_use]
+    pub fn components(&self) -> &[PathComponent] {
+        &self.components
+    }
+
+    /// Returns `true` iff every component in the path is hardened.
+    ///
+    /// Ed25519 derivation rejects paths that are not fully hardened.
+    #[must_use]
+    pub fn is_fully_hardened(&self) -> bool {
+        self.components.iter().all(|c| c.hardened)
+    }
+
+    /// Builds the canonical Aptos Ed25519 derivation path
+    /// `m/44'/637'/{account_index}'/0'/0'`.
+    ///
+    /// This matches the TypeScript SDK's `APTOS_HARDENED_REGEX`.
+    #[must_use]
+    pub fn aptos_ed25519(account_index: u32) -> Self {
+        Self {
+            components: vec![
+                PathComponent {
+                    index: BIP44_PURPOSE,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: APTOS_COIN_TYPE,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: account_index,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: 0,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: 0,
+                    hardened: true,
+                },
+            ],
+        }
+    }
+
+    /// Builds the canonical Aptos Secp256k1 derivation path
+    /// `m/44'/637'/{account_index}'/0/0`.
+    ///
+    /// The last two indices are intentionally **not** hardened, matching the
+    /// TypeScript SDK's `APTOS_BIP44_REGEX`. Hardened paths are also valid
+    /// for Secp256k1 but the Aptos default uses the mixed form.
+    #[must_use]
+    pub fn aptos_secp256k1(account_index: u32) -> Self {
+        Self {
+            components: vec![
+                PathComponent {
+                    index: BIP44_PURPOSE,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: APTOS_COIN_TYPE,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: account_index,
+                    hardened: true,
+                },
+                PathComponent {
+                    index: 0,
+                    hardened: false,
+                },
+                PathComponent {
+                    index: 0,
+                    hardened: false,
+                },
+            ],
+        }
+    }
+
+    /// Parses a derivation path of the form `m/44'/637'/0'/0'/0'`.
+    ///
+    /// Apostrophes (`'`) and lowercase `h` are accepted as hardened markers.
+    /// The leading `m/` (or `M/`) prefix is required.
+    ///
+    /// This is a convenience wrapper around the [`std::str::FromStr`]
+    /// implementation; both produce identical results.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AptosError::KeyDerivation`] if the path is malformed, a
+    /// component is missing, the numeric value exceeds 2^31 - 1, or the
+    /// path is empty.
+    #[allow(clippy::should_implement_trait)] // also implemented via FromStr below; inherent method kept for ergonomics so callers don't need a `use std::str::FromStr` import.
+    pub fn from_str(path: &str) -> AptosResult<Self> {
+        <Self as std::str::FromStr>::from_str(path)
+    }
+}
+
+impl std::str::FromStr for DerivationPath {
+    type Err = AptosError;
+
+    fn from_str(path: &str) -> AptosResult<Self> {
+        let mut parts = path.split('/');
+        let head = parts
+            .next()
+            .ok_or_else(|| AptosError::KeyDerivation("empty derivation path".to_string()))?;
+        if !matches!(head, "m" | "M") {
+            return Err(AptosError::KeyDerivation(format!(
+                "derivation path must start with 'm/', got: {path}"
+            )));
+        }
+
+        let mut components = Vec::new();
+        for raw in parts {
+            if raw.is_empty() {
+                return Err(AptosError::KeyDerivation(format!(
+                    "empty component in derivation path: {path}"
+                )));
+            }
+            let (digits, hardened) = if let Some(rest) = raw.strip_suffix('\'') {
+                (rest, true)
+            } else if let Some(rest) = raw.strip_suffix('h') {
+                (rest, true)
+            } else {
+                (raw, false)
+            };
+
+            let index: u32 = digits.parse().map_err(|_| {
+                AptosError::KeyDerivation(format!(
+                    "invalid numeric component '{raw}' in derivation path: {path}"
+                ))
+            })?;
+
+            if index & HARDENED_OFFSET != 0 {
+                return Err(AptosError::KeyDerivation(format!(
+                    "derivation index {index} exceeds 2^31 - 1 in path: {path}"
+                )));
+            }
+
+            components.push(PathComponent { index, hardened });
+        }
+
+        if components.is_empty() {
+            return Err(AptosError::KeyDerivation(format!(
+                "derivation path has no components: {path}"
+            )));
+        }
+
+        Ok(Self { components })
+    }
+}
+
+impl std::fmt::Display for DerivationPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("m")?;
+        for c in &self.components {
+            if c.hardened {
+                write!(f, "/{}'", c.index)?;
+            } else {
+                write!(f, "/{}", c.index)?;
+            }
+        }
+        Ok(())
+    }
+}
 
 /// A BIP-39 mnemonic phrase for key derivation.
 ///
@@ -112,17 +338,40 @@ impl Mnemonic {
         Ok(mnemonic.to_seed(passphrase))
     }
 
-    /// Derives an Ed25519 private key using the Aptos derivation path.
-    ///
-    /// Path: `m/44'/637'/0'/0'/index'`
+    /// Derives an Ed25519 private key using the Aptos default path
+    /// `m/44'/637'/0'/0'/0'` with the given address index.
     ///
     /// # Errors
     ///
     /// Returns an error if key derivation fails or the derived key is invalid.
     #[cfg(feature = "ed25519")]
     pub fn derive_ed25519_key(&self, index: u32) -> AptosResult<crate::crypto::Ed25519PrivateKey> {
+        self.derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(index))
+    }
+
+    /// Derives an Ed25519 private key at a custom BIP-44 path.
+    ///
+    /// All components of `path` must be hardened, matching SLIP-0010 (Ed25519
+    /// has no non-hardened child derivation).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path contains a non-hardened component, if
+    /// HMAC/SLIP-0010 derivation fails, or if the resulting key bytes do not
+    /// form a valid Ed25519 private key.
+    #[cfg(feature = "ed25519")]
+    pub fn derive_ed25519_key_at_path(
+        &self,
+        path: &DerivationPath,
+    ) -> AptosResult<crate::crypto::Ed25519PrivateKey> {
+        if !path.is_fully_hardened() {
+            return Err(AptosError::KeyDerivation(format!(
+                "Ed25519 derivation requires every path component to be hardened; got {path}"
+            )));
+        }
+
         let mut seed = self.to_seed()?;
-        let result = derive_ed25519_from_seed(&seed, index);
+        let result = derive_ed25519_at_path(&seed, path);
         // SECURITY: Zeroize seed after use
         zeroize::Zeroize::zeroize(&mut seed);
         let mut key = result?;
@@ -131,13 +380,52 @@ impl Mnemonic {
         zeroize::Zeroize::zeroize(&mut key);
         private_key
     }
+
+    /// Derives a Secp256k1 private key using the Aptos default path
+    /// `m/44'/637'/0'/0/0` with the given address index.
+    ///
+    /// The last two indices are non-hardened by convention, matching the
+    /// TypeScript SDK.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key derivation fails or the derived scalar is
+    /// invalid (probability ~2^-127 per step, effectively never).
+    #[cfg(feature = "secp256k1")]
+    pub fn derive_secp256k1_key(
+        &self,
+        index: u32,
+    ) -> AptosResult<crate::crypto::Secp256k1PrivateKey> {
+        self.derive_secp256k1_key_at_path(&DerivationPath::aptos_secp256k1(index))
+    }
+
+    /// Derives a Secp256k1 private key at a custom BIP-32 path.
+    ///
+    /// Supports hardened and non-hardened components per BIP-32.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if HMAC fails, if any intermediate scalar is invalid
+    /// (zero or >= curve order -- vanishingly rare), or if the final 32 bytes
+    /// do not form a valid Secp256k1 private key.
+    #[cfg(feature = "secp256k1")]
+    pub fn derive_secp256k1_key_at_path(
+        &self,
+        path: &DerivationPath,
+    ) -> AptosResult<crate::crypto::Secp256k1PrivateKey> {
+        let mut seed = self.to_seed()?;
+        let result = derive_secp256k1_at_path(&seed, path);
+        zeroize::Zeroize::zeroize(&mut seed);
+        let mut bytes = result?;
+        let key = crate::crypto::Secp256k1PrivateKey::from_bytes(&bytes);
+        zeroize::Zeroize::zeroize(&mut bytes);
+        key
+    }
 }
 
-/// Derives an Ed25519 key from a seed using the Aptos BIP-44 path.
-///
-/// This implements a simplified SLIP-0010 derivation for Ed25519.
+/// Derives an Ed25519 key from a seed using SLIP-0010 along the given path.
 #[cfg(feature = "ed25519")]
-fn derive_ed25519_from_seed(seed: &[u8], index: u32) -> AptosResult<[u8; 32]> {
+fn derive_ed25519_at_path(seed: &[u8], path: &DerivationPath) -> AptosResult<[u8; 32]> {
     use hmac::{Hmac, Mac};
     use sha2::Sha512;
 
@@ -154,23 +442,10 @@ fn derive_ed25519_from_seed(seed: &[u8], index: u32) -> AptosResult<[u8; 32]> {
     key.copy_from_slice(&result[..32]);
     chain_code.copy_from_slice(&result[32..]);
 
-    // Aptos derivation path: m/44'/637'/0'/0'/index'
-    // All indices are hardened (with 0x80000000 offset).
-    // Hex literals on the constants below silence
-    // clippy::decimal_literal_in_bitwise_op (which fired starting
-    // in Rust 1.95) without changing any of the encoded values.
-    let path = [
-        0x0000_002Cu32 | 0x8000_0000, // 44'  (BIP-44 purpose)
-        0x0000_027Du32 | 0x8000_0000, // 637' (Aptos coin type)
-        0x8000_0000,                  // 0'   (account)
-        0x8000_0000,                  // 0'   (change)
-        index | 0x8000_0000,          // index' (address index)
-    ];
-
-    for child_index in path {
+    for component in path.components() {
         let mut data = vec![0u8];
         data.extend_from_slice(&key);
-        data.extend_from_slice(&child_index.to_be_bytes());
+        data.extend_from_slice(&component.encoded().to_be_bytes());
 
         let mut mac = HmacSha512::new_from_slice(&chain_code)
             .map_err(|e| AptosError::KeyDerivation(e.to_string()))?;
@@ -190,6 +465,100 @@ fn derive_ed25519_from_seed(seed: &[u8], index: u32) -> AptosResult<[u8; 32]> {
     Ok(key)
 }
 
+/// Derives a Secp256k1 private key from a seed using BIP-32 along `path`.
+///
+/// Supports both hardened and non-hardened components. For non-hardened
+/// derivation the parent compressed public key is fed into HMAC; the child
+/// scalar is `(I_L + k_par) mod n`.
+#[cfg(feature = "secp256k1")]
+fn derive_secp256k1_at_path(seed: &[u8], path: &DerivationPath) -> AptosResult<[u8; 32]> {
+    use hmac::{Hmac, Mac};
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use k256::{NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey};
+    use sha2::Sha512;
+
+    type HmacSha512 = Hmac<Sha512>;
+
+    // BIP-32 master key derivation: HMAC-SHA512(key = "Bitcoin seed", seed)
+    let mut mac = HmacSha512::new_from_slice(b"Bitcoin seed")
+        .map_err(|e| AptosError::KeyDerivation(e.to_string()))?;
+    mac.update(seed);
+    let result = mac.finalize().into_bytes();
+
+    let mut key_bytes = [0u8; 32];
+    let mut chain_code = [0u8; 32];
+    key_bytes.copy_from_slice(&result[..32]);
+    chain_code.copy_from_slice(&result[32..]);
+
+    // Validate master key forms a valid scalar.
+    let mut parent = SecretKey::from_slice(&key_bytes)
+        .map_err(|e| AptosError::KeyDerivation(format!("invalid master scalar: {e}")))?;
+
+    for component in path.components() {
+        let encoded = component.encoded();
+        let data = if component.hardened {
+            // 0x00 || ser_256(k_par) || ser_32(i)
+            let mut buf = Vec::with_capacity(1 + 32 + 4);
+            buf.push(0u8);
+            buf.extend_from_slice(&parent.to_bytes());
+            buf.extend_from_slice(&encoded.to_be_bytes());
+            buf
+        } else {
+            // ser_P(K_par) || ser_32(i)  -- compressed public key (33 bytes)
+            let pub_key: PublicKey = parent.public_key();
+            let encoded_point = pub_key.to_encoded_point(true);
+            let mut buf = Vec::with_capacity(33 + 4);
+            buf.extend_from_slice(encoded_point.as_bytes());
+            buf.extend_from_slice(&encoded.to_be_bytes());
+            buf
+        };
+
+        let mut mac = HmacSha512::new_from_slice(&chain_code)
+            .map_err(|e| AptosError::KeyDerivation(e.to_string()))?;
+        mac.update(&data);
+        let result = mac.finalize().into_bytes();
+
+        // Reject I_L >= n or I_L == 0 by requiring a valid NonZeroScalar.
+        // `NonZeroScalar::try_from(&[u8])` returns Err in both failure modes.
+        let il_scalar = NonZeroScalar::try_from(&result[..32]).map_err(|e| {
+            AptosError::KeyDerivation(format!(
+                "BIP-32 derivation produced invalid intermediate scalar: {e}"
+            ))
+        })?;
+
+        // child_scalar = I_L + k_par (mod n)
+        let parent_scalar: Scalar = *parent.to_nonzero_scalar().as_ref();
+        let child_scalar = *il_scalar.as_ref() + parent_scalar;
+
+        let child_nz =
+            Option::<NonZeroScalar>::from(NonZeroScalar::new(child_scalar)).ok_or_else(|| {
+                AptosError::KeyDerivation(
+                    "BIP-32 derivation produced zero child scalar".to_string(),
+                )
+            })?;
+        parent = SecretKey::from(child_nz);
+
+        // Sanity: the child public key must be on the curve (it is, by
+        // construction, since child_scalar is a non-zero scalar). The
+        // projective-point form is computed implicitly by `parent.public_key()`
+        // on the next iteration. We do not need to re-derive it here, but the
+        // reference is kept so future changes don't accidentally drop it.
+        let _ = ProjectivePoint::GENERATOR;
+
+        // Update chain code from I_R.
+        chain_code.copy_from_slice(&result[32..]);
+    }
+
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&parent.to_bytes());
+
+    // SECURITY: Zeroize transient buffers.
+    zeroize::Zeroize::zeroize(&mut key_bytes);
+    zeroize::Zeroize::zeroize(&mut chain_code);
+
+    Ok(out)
+}
+
 impl std::fmt::Debug for Mnemonic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Mnemonic([REDACTED])")
@@ -199,6 +568,8 @@ impl std::fmt::Debug for Mnemonic {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TEST_PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     #[test]
     fn test_generate_mnemonic() {
@@ -216,9 +587,8 @@ mod tests {
 
     #[test]
     fn test_parse_mnemonic() {
-        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
-        assert_eq!(mnemonic.phrase(), phrase);
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        assert_eq!(mnemonic.phrase(), TEST_PHRASE);
     }
 
     #[test]
@@ -227,10 +597,63 @@ mod tests {
     }
 
     #[test]
+    fn test_path_from_str_hardened() {
+        let path = DerivationPath::from_str("m/44'/637'/0'/0'/0'").unwrap();
+        assert!(path.is_fully_hardened());
+        assert_eq!(path.components().len(), 5);
+        assert_eq!(path.to_string(), "m/44'/637'/0'/0'/0'");
+    }
+
+    #[test]
+    fn test_path_from_str_mixed() {
+        let path = DerivationPath::from_str("m/44'/637'/0'/0/0").unwrap();
+        assert!(!path.is_fully_hardened());
+        let comps = path.components();
+        assert!(comps[0].hardened && comps[1].hardened && comps[2].hardened);
+        assert!(!comps[3].hardened && !comps[4].hardened);
+    }
+
+    #[test]
+    fn test_path_from_str_h_marker() {
+        // Lowercase `h` is also a hardened marker.
+        let path = DerivationPath::from_str("m/44h/637h/0h").unwrap();
+        assert!(path.is_fully_hardened());
+    }
+
+    #[test]
+    fn test_path_from_str_rejects_bad_prefix() {
+        assert!(DerivationPath::from_str("44'/637'").is_err());
+        assert!(DerivationPath::from_str("").is_err());
+        assert!(DerivationPath::from_str("m").is_err());
+        assert!(DerivationPath::from_str("m/44'/abc/0").is_err());
+    }
+
+    #[test]
+    fn test_path_from_str_rejects_oversize_index() {
+        // 2^31 sets the hardened bit -- reject it as a raw numeric value.
+        assert!(DerivationPath::from_str("m/2147483648").is_err());
+    }
+
+    #[test]
+    fn test_aptos_default_paths() {
+        assert_eq!(
+            DerivationPath::aptos_ed25519(0).to_string(),
+            "m/44'/637'/0'/0'/0'"
+        );
+        assert_eq!(
+            DerivationPath::aptos_secp256k1(0).to_string(),
+            "m/44'/637'/0'/0/0"
+        );
+        assert_eq!(
+            DerivationPath::aptos_ed25519(5).to_string(),
+            "m/44'/637'/5'/0'/0'"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "ed25519")]
     fn test_derive_ed25519_key() {
-        let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
 
         let key1 = mnemonic.derive_ed25519_key(0).unwrap();
         let key2 = mnemonic.derive_ed25519_key(0).unwrap();
@@ -238,5 +661,82 @@ mod tests {
 
         let key3 = mnemonic.derive_ed25519_key(1).unwrap();
         assert_ne!(key1.to_bytes(), key3.to_bytes());
+    }
+
+    #[test]
+    #[cfg(feature = "ed25519")]
+    fn test_derive_ed25519_at_path_rejects_unhardened() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let path = DerivationPath::from_str("m/44'/637'/0'/0/0").unwrap();
+        let err = mnemonic.derive_ed25519_key_at_path(&path).unwrap_err();
+        assert!(matches!(err, AptosError::KeyDerivation(_)));
+    }
+
+    #[test]
+    #[cfg(feature = "ed25519")]
+    fn test_derive_ed25519_default_matches_path() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let via_index = mnemonic.derive_ed25519_key(3).unwrap();
+        let via_path = mnemonic
+            .derive_ed25519_key_at_path(&DerivationPath::aptos_ed25519(3))
+            .unwrap();
+        assert_eq!(via_index.to_bytes(), via_path.to_bytes());
+    }
+
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn test_derive_secp256k1_deterministic() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let key1 = mnemonic.derive_secp256k1_key(0).unwrap();
+        let key2 = mnemonic.derive_secp256k1_key(0).unwrap();
+        assert_eq!(key1.to_bytes(), key2.to_bytes());
+
+        let key3 = mnemonic.derive_secp256k1_key(1).unwrap();
+        assert_ne!(key1.to_bytes(), key3.to_bytes());
+    }
+
+    /// Cross-SDK regression: the abandon-test mnemonic derived at the
+    /// canonical Aptos Secp256k1 path `m/44'/637'/0'/0/0` must produce this
+    /// exact private key. Changes to BIP-32 derivation that move this byte
+    /// sequence are silent regressions vs the TypeScript SDK and MUST be
+    /// cross-checked there before updating the fixture.
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn test_derive_secp256k1_pinned_aptos_vector() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let key = mnemonic.derive_secp256k1_key(0).unwrap();
+        assert_eq!(
+            const_hex::encode(key.to_bytes()),
+            "4613c3acaffc152273c102a6b27f6f4209e1d54cac18ad0ac96b5892b7d7bf91",
+        );
+    }
+
+    /// Cross-validates the BIP-32 implementation against the well-known
+    /// Bitcoin reference vector: the abandon-test mnemonic at
+    /// `m/44'/0'/0'/0/0` (coin type 0, not Aptos) must yield the canonical
+    /// Bitcoin private key. Verifies HMAC master derivation, hardened
+    /// derivation, and non-hardened (public-key-based) derivation in a
+    /// single fixture. Source: any reputable BIP-32 / mnemonic-to-key
+    /// reference for the all-zero entropy mnemonic.
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn test_derive_secp256k1_bitcoin_reference_vector() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let path = DerivationPath::from_str("m/44'/0'/0'/0/0").unwrap();
+        let key = mnemonic.derive_secp256k1_key_at_path(&path).unwrap();
+        assert_eq!(
+            const_hex::encode(key.to_bytes()),
+            "e284129cc0922579a535bbf4d1a3b25773090d28c909bc0fed73b5e0222cc372",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn test_derive_secp256k1_custom_path() {
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let path = DerivationPath::from_str("m/44'/637'/0'/0/0").unwrap();
+        let via_path = mnemonic.derive_secp256k1_key_at_path(&path).unwrap();
+        let via_index = mnemonic.derive_secp256k1_key(0).unwrap();
+        assert_eq!(via_path.to_bytes(), via_index.to_bytes());
     }
 }

--- a/crates/aptos-sdk/src/account/mnemonic.rs
+++ b/crates/aptos-sdk/src/account/mnemonic.rs
@@ -369,7 +369,8 @@ impl Mnemonic {
     }
 
     /// Derives an Ed25519 private key using the Aptos default path
-    /// `m/44'/637'/0'/0'/0'` with the given address index.
+    /// `m/44'/637'/0'/0'/{address_index}'`, where `index` selects the
+    /// 5th (address) component. Index `0` yields `m/44'/637'/0'/0'/0'`.
     ///
     /// # Errors
     ///
@@ -412,7 +413,8 @@ impl Mnemonic {
     }
 
     /// Derives a Secp256k1 private key using the Aptos default path
-    /// `m/44'/637'/0'/0/0` with the given address index.
+    /// `m/44'/637'/0'/0/{address_index}`, where `index` selects the 5th
+    /// (address) component. Index `0` yields `m/44'/637'/0'/0/0`.
     ///
     /// The last two indices are non-hardened by convention, matching the
     /// TypeScript SDK.
@@ -526,13 +528,13 @@ fn derive_secp256k1_at_path(seed: &[u8], path: &DerivationPath) -> AptosResult<[
 
     for component in path.components() {
         let encoded = component.encoded();
-        let data = if component.hardened() {
-            // 0x00 || ser_256(k_par) || ser_32(i)
+        let (mut data, hardened) = if component.hardened() {
+            // 0x00 || ser_256(k_par) || ser_32(i)  -- contains parent secret
             let mut buf = Vec::with_capacity(1 + 32 + 4);
             buf.push(0u8);
             buf.extend_from_slice(&parent.to_bytes());
             buf.extend_from_slice(&encoded.to_be_bytes());
-            buf
+            (buf, true)
         } else {
             // ser_P(K_par) || ser_32(i)  -- compressed public key (33 bytes)
             let pub_key: PublicKey = parent.public_key();
@@ -540,16 +542,25 @@ fn derive_secp256k1_at_path(seed: &[u8], path: &DerivationPath) -> AptosResult<[
             let mut buf = Vec::with_capacity(33 + 4);
             buf.extend_from_slice(encoded_point.as_bytes());
             buf.extend_from_slice(&encoded.to_be_bytes());
-            buf
+            (buf, false)
         };
 
         let mut mac = HmacSha512::new_from_slice(&chain_code)
             .map_err(|e| AptosError::KeyDerivation(e.to_string()))?;
         mac.update(&data);
         let result = mac.finalize().into_bytes();
+        if hardened {
+            // SECURITY: data contained the parent private key for hardened
+            // derivation; zeroize before dropping.
+            zeroize::Zeroize::zeroize(&mut data);
+        }
 
-        // Reject I_L >= n or I_L == 0 by requiring a valid NonZeroScalar.
-        // `NonZeroScalar::try_from(&[u8])` returns Err in both failure modes.
+        // BIP-32 spec note: if I_L >= n or the derived child scalar is zero,
+        // the spec recommends proceeding with index i+1. We deliberately
+        // error instead, matching the Rust `bip32` crate: silently advancing
+        // the index would change the path the caller asked for, and the
+        // probability of either failure is ~2^-127 per component. Callers
+        // that hit this can pick a different address index explicitly.
         let il_scalar = NonZeroScalar::try_from(&result[..32]).map_err(|e| {
             AptosError::KeyDerivation(format!(
                 "BIP-32 derivation produced invalid intermediate scalar: {e}"
@@ -831,18 +842,20 @@ mod tests {
     fn test_passphrase_changes_derived_key() {
         // BIP-39 mandates the passphrase be folded into the seed; verify
         // the derived key is sensitive to it (otherwise the "secret
-        // passphrase" feature would be a no-op).
+        // passphrase" feature would be a no-op). We compare derived key
+        // bytes directly rather than just the seeds.
         let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
         let seed_default = mnemonic.to_seed().unwrap();
         let seed_passphrase = mnemonic.to_seed_with_passphrase("hunter2").unwrap();
         assert_ne!(seed_default, seed_passphrase);
-        // And the derived key follows accordingly via the seed.
-        let key = mnemonic.derive_ed25519_key(0).unwrap();
-        // Re-derive at the same path through the seed-with-passphrase
-        // path: there's no public `derive_*_from_seed` so we just assert
-        // the seed itself differs (key sensitivity follows by construction
-        // since the SLIP-0010 master HMAC is keyed by the seed).
-        assert_eq!(key.to_bytes().len(), 32);
+
+        let path = DerivationPath::aptos_ed25519(0).unwrap();
+        let key_default = derive_ed25519_at_path(&seed_default, &path).unwrap();
+        let key_passphrase = derive_ed25519_at_path(&seed_passphrase, &path).unwrap();
+        assert_ne!(
+            key_default, key_passphrase,
+            "BIP-39 passphrase must produce a distinct derived key"
+        );
     }
 
     #[test]

--- a/crates/aptos-sdk/src/account/mnemonic.rs
+++ b/crates/aptos-sdk/src/account/mnemonic.rs
@@ -731,6 +731,82 @@ mod tests {
     }
 
     #[test]
+    fn test_path_component_encoded_sets_hardened_bit() {
+        let hardened = PathComponent {
+            index: 44,
+            hardened: true,
+        };
+        let unhardened = PathComponent {
+            index: 44,
+            hardened: false,
+        };
+        assert_eq!(hardened.encoded(), 0x8000_002C);
+        assert_eq!(unhardened.encoded(), 44);
+    }
+
+    #[test]
+    fn test_path_display_roundtrip() {
+        for s in ["m/44'/637'/0'/0/0", "m/44'/637'/3'/0'/0'", "m/0"] {
+            let path = DerivationPath::from_str(s).unwrap();
+            assert_eq!(path.to_string(), s, "roundtrip drifted for {s}");
+        }
+    }
+
+    #[test]
+    fn test_path_from_str_via_parse_trait() {
+        // The FromStr trait impl exists so callers can `path.parse()` --
+        // verify it returns the same shape as the inherent constructor.
+        use std::str::FromStr;
+        let via_inherent = DerivationPath::from_str("m/44'/637'/0'/0/0").unwrap();
+        let via_trait: DerivationPath = "m/44'/637'/0'/0/0".parse().unwrap();
+        let via_fromstr = <DerivationPath as FromStr>::from_str("m/44'/637'/0'/0/0").unwrap();
+        assert_eq!(via_inherent, via_trait);
+        assert_eq!(via_inherent, via_fromstr);
+    }
+
+    #[test]
+    fn test_path_from_str_rejects_empty_component() {
+        // Double slash should not be silently absorbed into a single segment.
+        assert!(DerivationPath::from_str("m//44'").is_err());
+        assert!(DerivationPath::from_str("m/44'/").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "ed25519")]
+    fn test_passphrase_changes_derived_key() {
+        // BIP-39 mandates the passphrase be folded into the seed; verify
+        // the derived key is sensitive to it (otherwise the "secret
+        // passphrase" feature would be a no-op).
+        let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let seed_default = mnemonic.to_seed().unwrap();
+        let seed_passphrase = mnemonic.to_seed_with_passphrase("hunter2").unwrap();
+        assert_ne!(seed_default, seed_passphrase);
+        // And the derived key follows accordingly via the seed.
+        let key = mnemonic.derive_ed25519_key(0).unwrap();
+        // Re-derive at the same path through the seed-with-passphrase
+        // path: there's no public `derive_*_from_seed` so we just assert
+        // the seed itself differs (key sensitivity follows by construction
+        // since the SLIP-0010 master HMAC is keyed by the seed).
+        assert_eq!(key.to_bytes().len(), 32);
+    }
+
+    #[test]
+    #[cfg(feature = "secp256k1")]
+    fn test_derive_secp256k1_different_paths_produce_different_keys() {
+        // Sanity: distinct paths must produce distinct keys (otherwise
+        // a derivation bug could be hiding behind a single-path test).
+        let m = Mnemonic::from_phrase(TEST_PHRASE).unwrap();
+        let k0 = m.derive_secp256k1_key(0).unwrap();
+        let k1 = m.derive_secp256k1_key(1).unwrap();
+        let k_bitcoin = m
+            .derive_secp256k1_key_at_path(&DerivationPath::from_str("m/44'/0'/0'/0/0").unwrap())
+            .unwrap();
+        assert_ne!(k0.to_bytes(), k1.to_bytes());
+        assert_ne!(k0.to_bytes(), k_bitcoin.to_bytes());
+        assert_ne!(k1.to_bytes(), k_bitcoin.to_bytes());
+    }
+
+    #[test]
     #[cfg(feature = "secp256k1")]
     fn test_derive_secp256k1_custom_path() {
         let mnemonic = Mnemonic::from_phrase(TEST_PHRASE).unwrap();

--- a/crates/aptos-sdk/src/account/mod.rs
+++ b/crates/aptos-sdk/src/account/mod.rs
@@ -55,7 +55,7 @@ pub use keyless::{
     KeylessSignature, OidcProvider, Pepper, PepperService, ProverService, ZkProof,
 };
 #[cfg(feature = "mnemonic")]
-pub use mnemonic::Mnemonic;
+pub use mnemonic::{DerivationPath, Mnemonic, PathComponent};
 #[cfg(feature = "ed25519")]
 pub use multi_ed25519::MultiEd25519Account;
 pub use multi_key::{AnyPrivateKey, MultiKeyAccount};

--- a/crates/aptos-sdk/src/api/ans.rs
+++ b/crates/aptos-sdk/src/api/ans.rs
@@ -1,0 +1,105 @@
+//! Aptos Names Service (ANS) client -- **scaffold / not yet implemented**.
+//!
+//! This module exists so `AGENTS.md` can stop referencing a missing file,
+//! and so future work can land in one obvious place. **Nothing here issues
+//! a network call yet.**
+//!
+//! # Scope when implemented
+//!
+//! At minimum we want:
+//!
+//! - `lookup(name)` -- resolve a `.apt` / sub-domain string into an
+//!   [`AccountAddress`].
+//! - `reverse_lookup(address)` -- find the primary name registered to an
+//!   address, if any.
+//!
+//! At extension time:
+//!
+//! - Register / renew flows (entry-function builders against the on-chain
+//!   ANS contract -- requires pinned contract addresses per network and a
+//!   plan for how the SDK should pick them).
+//! - Sub-domain queries.
+//!
+//! # Why not implemented yet
+//!
+//! The TS SDK's ANS module hard-codes contract addresses per network and
+//! relies on the indexer for some lookups. Mirroring that 1:1 without
+//! making network-specific decisions visible to callers needs design
+//! work that's tracked separately from the May-2026 audit follow-ups. See
+//! `AUDIT_SUMMARY_2026-05.md` and the audit follow-up commits for context.
+
+use crate::api::FullnodeClient;
+use crate::error::{AptosError, AptosResult};
+use crate::types::AccountAddress;
+
+/// Skeleton client for Aptos Names Service.
+///
+/// All methods currently return
+/// [`AptosError::Internal`]
+/// so callers fail fast rather than silently accepting placeholder values.
+#[derive(Debug, Clone)]
+pub struct AnsClient {
+    #[allow(dead_code)] // wired up when lookups land
+    fullnode: FullnodeClient,
+}
+
+impl AnsClient {
+    /// Constructs a new ANS client bound to a given fullnode.
+    #[must_use]
+    pub fn new(fullnode: FullnodeClient) -> Self {
+        Self { fullnode }
+    }
+
+    /// Resolves an ANS name (e.g. `"alice.apt"`) to its registered
+    /// [`AccountAddress`].
+    ///
+    /// # Errors
+    ///
+    /// Currently always returns [`AptosError::Internal`]; the lookup is
+    /// scheduled but not yet wired up. Track progress against the audit
+    /// follow-up issue cited in this module's docs.
+    pub async fn lookup(&self, _name: &str) -> AptosResult<AccountAddress> {
+        Err(AptosError::Internal(
+            "ANS lookup is not yet implemented in the Rust SDK (tracked as an audit \
+             follow-up); use the on-chain `0x...::router::get_address` view \
+             function directly for now"
+                .to_string(),
+        ))
+    }
+
+    /// Finds the primary ANS name registered to a given address, if any.
+    ///
+    /// # Errors
+    ///
+    /// Currently always returns [`AptosError::Internal`]; the reverse
+    /// lookup is scheduled but not yet wired up.
+    pub async fn reverse_lookup(&self, _address: AccountAddress) -> AptosResult<Option<String>> {
+        Err(AptosError::Internal(
+            "ANS reverse lookup is not yet implemented in the Rust SDK \
+             (tracked as an audit follow-up)"
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AptosConfig;
+
+    #[tokio::test]
+    async fn lookup_is_unsupported() {
+        let fullnode = FullnodeClient::new(AptosConfig::testnet()).unwrap();
+        let ans = AnsClient::new(fullnode);
+        let err = ans.lookup("alice.apt").await.unwrap_err();
+        assert!(matches!(err, AptosError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn reverse_lookup_is_unsupported() {
+        let fullnode = FullnodeClient::new(AptosConfig::testnet()).unwrap();
+        let ans = AnsClient::new(fullnode);
+        let err = ans.reverse_lookup(AccountAddress::ONE).await.unwrap_err();
+        assert!(matches!(err, AptosError::Internal(_)));
+    }
+}

--- a/crates/aptos-sdk/src/api/fullnode.rs
+++ b/crates/aptos-sdk/src/api/fullnode.rs
@@ -167,7 +167,11 @@ impl FullnodeClient {
             .map_err(|e| AptosError::Internal(format!("failed to parse sequence number: {e}")))
     }
 
-    /// Gets all resources for an account.
+    /// Gets all resources for an account in a single page (uses the
+    /// fullnode's default page size; large accounts may be truncated).
+    ///
+    /// For paginated access on accounts that hold many resources, use
+    /// [`get_account_resources_paginated`](Self::get_account_resources_paginated).
     ///
     /// # Errors
     ///
@@ -177,7 +181,32 @@ impl FullnodeClient {
         &self,
         address: AccountAddress,
     ) -> AptosResult<AptosResponse<Vec<Resource>>> {
-        let url = self.build_url(&format!("accounts/{address}/resources"));
+        self.get_account_resources_paginated(address, None, None)
+            .await
+    }
+
+    /// Gets resources for an account with explicit pagination cursors.
+    ///
+    /// * `start` -- opaque state-key cursor returned by the previous page
+    ///   (omit for the first page).
+    /// * `limit` -- maximum number of resources to return on this page.
+    ///   The fullnode caps this server-side; callers should not assume
+    ///   their requested limit is honored verbatim.
+    ///
+    /// Matches the TypeScript SDK's `getAccountResources({ start, limit })`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails, the API returns an error status code,
+    /// or the response cannot be parsed as JSON.
+    pub async fn get_account_resources_paginated(
+        &self,
+        address: AccountAddress,
+        start: Option<u64>,
+        limit: Option<u16>,
+    ) -> AptosResult<AptosResponse<Vec<Resource>>> {
+        let mut url = self.build_url(&format!("accounts/{address}/resources"));
+        append_start_limit(&mut url, start, limit);
         self.get_json(url).await
     }
 
@@ -200,7 +229,12 @@ impl FullnodeClient {
         self.get_json(url).await
     }
 
-    /// Gets all modules for an account.
+    /// Gets all modules for an account in a single page (uses the
+    /// fullnode's default page size; accounts that publish many modules
+    /// may be truncated).
+    ///
+    /// For paginated access, use
+    /// [`get_account_modules_paginated`](Self::get_account_modules_paginated).
     ///
     /// # Errors
     ///
@@ -210,7 +244,28 @@ impl FullnodeClient {
         &self,
         address: AccountAddress,
     ) -> AptosResult<AptosResponse<Vec<MoveModule>>> {
-        let url = self.build_url(&format!("accounts/{address}/modules"));
+        self.get_account_modules_paginated(address, None, None)
+            .await
+    }
+
+    /// Gets modules for an account with explicit pagination cursors.
+    ///
+    /// See [`get_account_resources_paginated`](Self::get_account_resources_paginated)
+    /// for `start` / `limit` semantics; they are interpreted the same way
+    /// by the fullnode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP request fails, the API returns an error status code,
+    /// or the response cannot be parsed as JSON.
+    pub async fn get_account_modules_paginated(
+        &self,
+        address: AccountAddress,
+        start: Option<u64>,
+        limit: Option<u16>,
+    ) -> AptosResult<AptosResponse<Vec<MoveModule>>> {
+        let mut url = self.build_url(&format!("accounts/{address}/modules"));
+        append_start_limit(&mut url, start, limit);
         self.get_json(url).await
     }
 
@@ -880,6 +935,23 @@ impl FullnodeClient {
     }
 }
 
+/// Appends `start` and `limit` query parameters to `url` when present.
+///
+/// Shared by paginated REST endpoints (`/accounts/{addr}/resources`,
+/// `/accounts/{addr}/modules`, ...) so the formatting stays consistent.
+fn append_start_limit(url: &mut Url, start: Option<u64>, limit: Option<u16>) {
+    if start.is_none() && limit.is_none() {
+        return;
+    }
+    let mut query = url.query_pairs_mut();
+    if let Some(start) = start {
+        query.append_pair("start", &start.to_string());
+    }
+    if let Some(limit) = limit {
+        query.append_pair("limit", &limit.to_string());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -891,7 +963,7 @@ mod tests {
     use crate::types::ChainId;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{method, path, path_regex},
+        matchers::{method, path, path_regex, query_param},
     };
 
     #[test]
@@ -1107,6 +1179,69 @@ mod tests {
 
         assert_eq!(result.data.len(), 1);
         assert!(result.data[0].abi.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_account_resources_paginated_sends_start_and_limit() {
+        let server = MockServer::start().await;
+
+        // Verify the SDK forwards both query params verbatim.
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/resources"))
+            .and(query_param("start", "42"))
+            .and(query_param("limit", "9"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        let result = client
+            .get_account_resources_paginated(AccountAddress::ONE, Some(42), Some(9))
+            .await
+            .unwrap();
+        assert_eq!(result.data.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_account_resources_no_pagination_omits_query() {
+        let server = MockServer::start().await;
+
+        // When both args are None, no `start`/`limit` query params should
+        // be appended -- the fullnode default page applies.
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/resources$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_resources(AccountAddress::ONE)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_account_modules_paginated_sends_limit_only() {
+        let server = MockServer::start().await;
+
+        // Only `limit` is sent when `start` is omitted -- caller is fetching
+        // the first page with a custom page size.
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/modules"))
+            .and(query_param("limit", "25"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_modules_paginated(AccountAddress::ONE, None, Some(25))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/aptos-sdk/src/api/fullnode.rs
+++ b/crates/aptos-sdk/src/api/fullnode.rs
@@ -187,8 +187,13 @@ impl FullnodeClient {
 
     /// Gets resources for an account with explicit pagination cursors.
     ///
-    /// * `start` -- opaque state-key cursor returned by the previous page
-    ///   (omit for the first page).
+    /// * `start` -- opaque cursor token returned by the previous page in
+    ///   the `x-aptos-cursor` header (and surfaced as
+    ///   [`AptosResponse::cursor`](super::response::AptosResponse#field.cursor)).
+    ///   The type is `Option<&str>` rather than `Option<u64>` so opaque
+    ///   non-numeric cursors round-trip losslessly. Pass `None` for the
+    ///   first page; for subsequent pages forward
+    ///   `previous_response.cursor.as_deref()`.
     /// * `limit` -- maximum number of resources to return on this page.
     ///   The fullnode caps this server-side; callers should not assume
     ///   their requested limit is honored verbatim.
@@ -202,7 +207,7 @@ impl FullnodeClient {
     pub async fn get_account_resources_paginated(
         &self,
         address: AccountAddress,
-        start: Option<u64>,
+        start: Option<&str>,
         limit: Option<u16>,
     ) -> AptosResult<AptosResponse<Vec<Resource>>> {
         let mut url = self.build_url(&format!("accounts/{address}/resources"));
@@ -261,7 +266,7 @@ impl FullnodeClient {
     pub async fn get_account_modules_paginated(
         &self,
         address: AccountAddress,
-        start: Option<u64>,
+        start: Option<&str>,
         limit: Option<u16>,
     ) -> AptosResult<AptosResponse<Vec<MoveModule>>> {
         let mut url = self.build_url(&format!("accounts/{address}/modules"));
@@ -939,13 +944,16 @@ impl FullnodeClient {
 ///
 /// Shared by paginated REST endpoints (`/accounts/{addr}/resources`,
 /// `/accounts/{addr}/modules`, ...) so the formatting stays consistent.
-fn append_start_limit(url: &mut Url, start: Option<u64>, limit: Option<u16>) {
+/// `start` is forwarded verbatim as a string so opaque pagination cursors
+/// returned in the `x-aptos-cursor` header round-trip losslessly (the
+/// fullnode does not promise numeric cursors).
+fn append_start_limit(url: &mut Url, start: Option<&str>, limit: Option<u16>) {
     if start.is_none() && limit.is_none() {
         return;
     }
     let mut query = url.query_pairs_mut();
     if let Some(start) = start {
-        query.append_pair("start", &start.to_string());
+        query.append_pair("start", start);
     }
     if let Some(limit) = limit {
         query.append_pair("limit", &limit.to_string());
@@ -1197,10 +1205,32 @@ mod tests {
 
         let client = create_mock_client(&server);
         let result = client
-            .get_account_resources_paginated(AccountAddress::ONE, Some(42), Some(9))
+            .get_account_resources_paginated(AccountAddress::ONE, Some("42"), Some(9))
             .await
             .unwrap();
         assert_eq!(result.data.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_account_resources_paginated_round_trips_opaque_cursor() {
+        // The `x-aptos-cursor` header is opaque (`Option<String>` on
+        // `AptosResponse`). A caller pulling page N+1 must be able to pass
+        // page N's cursor verbatim, even when it's not a decimal integer.
+        let server = MockServer::start().await;
+        let opaque = "0x0a1b2c3d_state_key_token";
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/resources"))
+            .and(query_param("start", opaque))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_resources_paginated(AccountAddress::ONE, Some(opaque), None)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -1238,7 +1268,7 @@ mod tests {
 
         let client = create_mock_client(&server);
         client
-            .get_account_resources_paginated(AccountAddress::ONE, Some(1234), None)
+            .get_account_resources_paginated(AccountAddress::ONE, Some("1234"), None)
             .await
             .unwrap();
     }
@@ -1257,7 +1287,7 @@ mod tests {
 
         let client = create_mock_client(&server);
         client
-            .get_account_modules_paginated(AccountAddress::ONE, Some(7), Some(100))
+            .get_account_modules_paginated(AccountAddress::ONE, Some("7"), Some(100))
             .await
             .unwrap();
     }

--- a/crates/aptos-sdk/src/api/fullnode.rs
+++ b/crates/aptos-sdk/src/api/fullnode.rs
@@ -1224,6 +1224,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_account_resources_paginated_sends_start_only() {
+        // Start without limit: caller is paging from a saved cursor and is
+        // happy with the fullnode default page size.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/resources"))
+            .and(query_param("start", "1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_resources_paginated(AccountAddress::ONE, Some(1234), None)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_account_modules_paginated_sends_start_and_limit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/modules"))
+            .and(query_param("start", "7"))
+            .and(query_param("limit", "100"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_modules_paginated(AccountAddress::ONE, Some(7), Some(100))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_account_modules_no_pagination_omits_query() {
+        // Symmetric with the resources variant: no `start` / `limit` query
+        // params should be appended when both are None.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path_regex(r"/v1/accounts/0x[0-9a-f]+/modules$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = create_mock_client(&server);
+        client
+            .get_account_modules(AccountAddress::ONE)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_get_account_modules_paginated_sends_limit_only() {
         let server = MockServer::start().await;
 

--- a/crates/aptos-sdk/src/api/mod.rs
+++ b/crates/aptos-sdk/src/api/mod.rs
@@ -5,7 +5,9 @@
 //! - [`FullnodeClient`] - REST API client for fullnode operations
 //! - [`FaucetClient`] - Client for funding accounts on testnets (feature-gated)
 //! - [`IndexerClient`] - GraphQL client for indexed data (feature-gated)
+//! - [`AnsClient`] - Aptos Names Service client (scaffold; see `ans.rs`)
 
+pub mod ans;
 pub mod fullnode;
 pub mod response;
 
@@ -15,6 +17,7 @@ mod faucet;
 #[cfg(feature = "indexer")]
 mod indexer;
 
+pub use ans::AnsClient;
 pub use fullnode::FullnodeClient;
 pub use response::{AptosResponse, GasEstimation, LedgerInfo, PendingTransaction};
 

--- a/crates/aptos-sdk/tests/behavioral/mod.rs
+++ b/crates/aptos-sdk/tests/behavioral/mod.rs
@@ -4,6 +4,9 @@
 //! without requiring a live network.
 
 #[cfg(feature = "ed25519")]
+mod wire_format;
+
+#[cfg(feature = "ed25519")]
 mod crypto_tests {
     use aptos_sdk::crypto::Ed25519PrivateKey;
 

--- a/crates/aptos-sdk/tests/behavioral/wire_format.rs
+++ b/crates/aptos-sdk/tests/behavioral/wire_format.rs
@@ -1,0 +1,265 @@
+//! Cross-SDK BCS wire-format fixtures.
+//!
+//! These tests pin the exact on-wire byte layout that the Rust SDK
+//! produces for a small set of representative inputs:
+//!
+//! - `RawTransaction` with sequence-number replay protection.
+//! - `RawTransaction::signing_message` (BCS + `APTOS::RawTransaction` prefix).
+//! - `RawTransactionOrderless::signing_message` (uses a different prefix).
+//! - `AccountAuthenticator::Ed25519` (legacy variant 0).
+//! - `AccountAuthenticator::SingleKey(AnyPublicKey::Ed25519)` (variant 2).
+//! - A nested generic `TypeTag`.
+//!
+//! Every fixture uses **deterministic** inputs (fixed keys, fixed values,
+//! fixed expiration) so the resulting bytes are reproducible. A divergence
+//! between this file and the TypeScript SDK constructed with the same inputs
+//! is a wire-format regression and MUST be triaged before merging: a
+//! corrupt authenticator or signing-message will silently produce
+//! `INVALID_SIGNATURE` on the chain even though Rust compiles and all the
+//! higher-level tests pass.
+
+#![cfg(feature = "ed25519")]
+
+use aptos_sdk::account::{Account, Ed25519Account, Ed25519SingleKeyAccount};
+use aptos_sdk::crypto::{AnyPublicKey, Ed25519PrivateKey, sha3_256};
+use aptos_sdk::transaction::TransactionPayload;
+use aptos_sdk::transaction::authenticator::{
+    AccountAuthenticator, Ed25519PublicKey as AuthEd25519PublicKey,
+    Ed25519Signature as AuthEd25519Signature,
+};
+use aptos_sdk::transaction::payload::EntryFunction;
+use aptos_sdk::transaction::types::{RawTransaction, RawTransactionOrderless};
+use aptos_sdk::types::{AccountAddress, ChainId, TypeTag};
+
+/// Deterministic Ed25519 key. The `0x01`-repeating pattern is also used by
+/// the existing `auth_key_tests` module so addresses match audited values.
+const FIXED_ED25519_SEED: [u8; 32] = [1u8; 32];
+
+/// Fixed expiration timestamp so BCS bytes are reproducible.
+const FIXED_EXPIRATION: u64 = 9_999_999_999;
+
+fn fixed_apt_transfer_payload() -> TransactionPayload {
+    let recipient = AccountAddress::from_hex("0x2").unwrap();
+    TransactionPayload::EntryFunction(EntryFunction::apt_transfer(recipient, 1_000_000).unwrap())
+}
+
+fn fixed_raw_transaction() -> RawTransaction {
+    RawTransaction {
+        sender: AccountAddress::ONE,
+        sequence_number: 42,
+        payload: fixed_apt_transfer_payload(),
+        max_gas_amount: 100_000,
+        gas_unit_price: 100,
+        expiration_timestamp_secs: FIXED_EXPIRATION,
+        chain_id: ChainId::testnet(),
+    }
+}
+
+#[test]
+fn raw_transaction_signing_message_prefix_is_correct() {
+    let raw = fixed_raw_transaction();
+    let msg = raw.signing_message().expect("signing message must build");
+
+    // Domain prefix: SHA3-256(b"APTOS::RawTransaction") =
+    //   b5e97db07fa0bd0e5598aa3643a9bc6f6693bddc1a9fec9e674a461eaa00b193
+    let expected_prefix = sha3_256(b"APTOS::RawTransaction");
+    assert_eq!(
+        &msg[..32],
+        &expected_prefix[..],
+        "domain prefix must be SHA3-256(\"APTOS::RawTransaction\")",
+    );
+
+    // Body == raw BCS of the RawTransaction.
+    let body = raw.to_bcs().unwrap();
+    assert_eq!(&msg[32..], &body[..]);
+}
+
+#[test]
+fn raw_transaction_bcs_layout_is_reproducible() {
+    // Pin the full BCS hex. Drives a future cross-check against the TS SDK
+    // constructed with identical inputs.
+    let raw = fixed_raw_transaction();
+    let hex = const_hex::encode(raw.to_bcs().unwrap());
+
+    // Sanity-check structurally before pinning the bytes:
+    //   32B sender || 8B seq || 1B payload-variant || ... || 1B chain_id
+    assert!(
+        hex.starts_with(
+            // sender = AccountAddress::ONE (LONG form, 32 bytes)
+            "0000000000000000000000000000000000000000000000000000000000000001\
+             2a00000000000000\
+             02"
+            .split_whitespace()
+            .collect::<String>()
+            .as_str()
+        ),
+        "leading bytes (sender + sequence_number + payload variant) drifted: {hex}",
+    );
+
+    // chain_id == ChainId::testnet() == 2 -> the final byte is `02`.
+    assert!(hex.ends_with("02"), "chain id byte drifted: {hex}");
+
+    // Sequence number 42 -> little-endian u64 -> 2a00000000000000.
+    assert!(
+        hex.contains("2a00000000000000"),
+        "sequence_number little-endian encoding drifted: {hex}",
+    );
+
+    // Max gas amount 100_000 -> little-endian u64 -> a086010000000000.
+    assert!(
+        hex.contains("a086010000000000"),
+        "max_gas_amount little-endian encoding drifted: {hex}",
+    );
+
+    // Gas unit price 100 -> little-endian u64 -> 6400000000000000.
+    assert!(
+        hex.contains("6400000000000000"),
+        "gas_unit_price little-endian encoding drifted: {hex}",
+    );
+
+    // Expiration 9_999_999_999 = 0x0000_0002_540B_E3FF -> LE u64 -> ffe30b5402000000.
+    assert!(
+        hex.contains("ffe30b5402000000"),
+        "expiration_timestamp_secs little-endian encoding drifted: {hex}",
+    );
+}
+
+#[test]
+fn orderless_signing_message_uses_distinct_prefix() {
+    // Orderless replay protection swaps the domain prefix; the nonce stays
+    // user-supplied so we use a fixed value to keep the message reproducible.
+    let raw = RawTransactionOrderless::with_nonce(
+        AccountAddress::ONE,
+        vec![0xde, 0xad, 0xbe, 0xef],
+        fixed_apt_transfer_payload(),
+        100_000,
+        100,
+        FIXED_EXPIRATION,
+        ChainId::testnet(),
+    );
+    let msg = raw.signing_message().unwrap();
+
+    let expected_prefix = sha3_256(b"APTOS::RawTransactionOrderless");
+    assert_eq!(&msg[..32], &expected_prefix[..]);
+
+    // The orderless prefix MUST differ from the sequenced one -- a regression
+    // that aliased them would let orderless txns replay forever.
+    assert_ne!(expected_prefix, sha3_256(b"APTOS::RawTransaction"));
+}
+
+#[test]
+fn account_authenticator_legacy_ed25519_bcs_layout_is_pinned() {
+    let account = Ed25519Account::from_private_key(
+        Ed25519PrivateKey::from_bytes(&FIXED_ED25519_SEED).unwrap(),
+    );
+    let message = b"fixture message";
+    let sig_bytes: [u8; 64] = account
+        .sign(message)
+        .unwrap()
+        .try_into()
+        .expect("ed25519 sig length = 64");
+    let mut pk_arr = [0u8; 32];
+    pk_arr.copy_from_slice(&account.public_key_bytes());
+
+    let auth = AccountAuthenticator::Ed25519 {
+        public_key: AuthEd25519PublicKey(pk_arr),
+        signature: AuthEd25519Signature(sig_bytes),
+    };
+    let bytes = aptos_bcs::to_bytes(&auth).unwrap();
+    let hex = const_hex::encode(&bytes);
+
+    // Layout (variant 0 / Ed25519):
+    //   0x00 || ULEB128(32) || pubkey(32) || ULEB128(64) || signature(64)
+    //   = 1 + 1 + 32 + 1 + 64 = 99 bytes.
+    assert_eq!(bytes.len(), 1 + 1 + 32 + 1 + 64, "BCS length mismatch");
+    assert!(
+        hex.starts_with("0020"),
+        "variant byte (0x00) + ULEB128(32) prefix drifted: {hex}",
+    );
+    // After 32-byte pubkey, the next byte must be ULEB128(64) = 0x40.
+    let sig_header_offset = (1 + 1 + 32) * 2;
+    assert_eq!(
+        &hex[sig_header_offset..sig_header_offset + 2],
+        "40",
+        "ULEB128(64) before signature drifted: {hex}",
+    );
+}
+
+#[test]
+fn account_authenticator_single_key_ed25519_bcs_layout_is_pinned() {
+    let account = Ed25519SingleKeyAccount::from_private_key(
+        Ed25519PrivateKey::from_bytes(&FIXED_ED25519_SEED).unwrap(),
+    );
+    let pk = account.public_key();
+    let any_pk_bytes = AnyPublicKey::ed25519(pk).to_bcs_bytes();
+
+    // AnyPublicKey::Ed25519 BCS = 0x00 (variant) || ULEB128(32) || 32 pubkey bytes
+    //   = 34 bytes.
+    assert_eq!(any_pk_bytes.len(), 1 + 1 + 32);
+    assert_eq!(
+        any_pk_bytes[0], 0x00,
+        "AnyPublicKey::Ed25519 must be variant 0",
+    );
+    assert_eq!(any_pk_bytes[1], 32, "ULEB128(32) length prefix");
+
+    // For a SingleKey authenticator the runtime BCS shape is
+    //   variant 2 || raw AnyPublicKey bytes || raw AnySignature bytes
+    // The Vec<u8> fields on `AccountAuthenticator::SingleKey` are emitted
+    // **inline** by the hand-rolled `serialize_account_auth_raw_pair` --
+    // matching the on-chain `SingleKeyAuthenticator { authenticator }`
+    // struct layout. There is NO outer ULEB128 length prefix on either
+    // blob; the structure is recoverable purely from the variant tags
+    // embedded in AnyPublicKey / AnySignature. Test that contract here
+    // because reverting to a derive-based Serialize would silently add
+    // the extra prefix bytes and break on-chain authentication.
+
+    // Build a synthetic SingleKey authenticator with the pre-serialized
+    // public key and a signature blob shaped like a real
+    //   AnySignature::Ed25519 = 0x00 || ULEB128(64) || 64 bytes
+    // (66 bytes total).
+    let synthetic_sig = {
+        let mut s = vec![0u8, 64u8];
+        s.extend_from_slice(&[0u8; 64]);
+        s
+    };
+    let auth = AccountAuthenticator::SingleKey {
+        public_key: any_pk_bytes.clone(),
+        signature: synthetic_sig,
+    };
+    let outer = aptos_bcs::to_bytes(&auth).unwrap();
+    let outer_hex = const_hex::encode(&outer);
+
+    // Outer = 0x02 (variant) || 34 AnyPublicKey bytes || 66 AnySignature bytes
+    //       = 1 + 34 + 66 = 101 bytes.
+    assert_eq!(outer.len(), 1 + 34 + 66);
+    assert!(
+        outer_hex.starts_with("0200"),
+        "SingleKey variant byte (0x02) + AnyPublicKey::Ed25519 variant (0x00) drifted: {outer_hex}",
+    );
+    // After 1-byte variant + 34-byte AnyPublicKey, the next byte must be
+    // the AnySignature::Ed25519 variant tag (0x00).
+    let sig_var_offset = (1 + 34) * 2;
+    assert_eq!(
+        &outer_hex[sig_var_offset..sig_var_offset + 2],
+        "00",
+        "AnySignature::Ed25519 variant tag drifted: {outer_hex}",
+    );
+}
+
+#[test]
+fn type_tag_nested_generic_bcs_embeds_inner_typetag() {
+    let outer = TypeTag::from_str_strict("0x1::coin::Coin<0x1::aptos_coin::AptosCoin>").unwrap();
+    let inner = TypeTag::aptos_coin();
+
+    let outer_bytes = aptos_bcs::to_bytes(&outer).unwrap();
+    let inner_bytes = aptos_bcs::to_bytes(&inner).unwrap();
+
+    let outer_hex = const_hex::encode(&outer_bytes);
+    let inner_hex = const_hex::encode(&inner_bytes);
+    // The outer TypeTag must contain the inner one verbatim -- otherwise
+    // generic instantiation has diverged from the on-chain `TypeTag` enum.
+    assert!(
+        outer_hex.contains(&inner_hex),
+        "outer TypeTag BCS ({outer_hex}) must contain inner ({inner_hex})",
+    );
+}

--- a/crates/aptos-sdk/tests/behavioral/wire_format.rs
+++ b/crates/aptos-sdk/tests/behavioral/wire_format.rs
@@ -247,6 +247,168 @@ fn account_authenticator_single_key_ed25519_bcs_layout_is_pinned() {
 }
 
 #[test]
+fn raw_transaction_full_bcs_hex_is_pinned() {
+    // Full hex pin so cross-SDK comparison reduces to a single equality
+    // check. The earlier `*_layout_is_reproducible` test asserts component
+    // substrings, which keeps the diagnostic readable when one field
+    // drifts; this one catches drift in any field but is harder to debug.
+    // Both are intentional: components for diagnosis, full hex for the
+    // single-line cross-SDK fixture comparison.
+    let raw = fixed_raw_transaction();
+    assert_eq!(
+        const_hex::encode(raw.to_bcs().unwrap()),
+        // sender(32) | seq(8) | payload_variant(1) | module_addr(32) |
+        //   module_name(uleb+13) | function(uleb+8) | type_args(uleb+0) |
+        //   args(uleb+2 + uleb+32 + 32B addr + uleb+8 + 8B amount) |
+        //   max_gas(8) | gas_price(8) | expiration(8) | chain_id(1)
+        "00000000000000000000000000000000000000000000000000000000000000012a000000000000000200000000000000000000000000000000000000000000000000000000000000010d6170746f735f6163636f756e74087472616e7366657200022000000000000000000000000000000000000000000000000000000000000000020840420f0000000000a0860100000000006400000000000000ffe30b540200000002",
+    );
+}
+
+#[cfg(feature = "ed25519")]
+#[test]
+fn account_authenticator_multi_ed25519_bcs_layout_is_pinned() {
+    // 2-of-3 MultiEd25519 with deterministic keys (seeds 1, 2, 3). The
+    // SDK signs with the first `threshold` private keys, so signatures 0
+    // and 1 are populated and the bitmap's two most-significant bits are
+    // set (`0b1100_0000` = 0xc0).
+    use aptos_sdk::account::MultiEd25519Account;
+    let keys: Vec<Ed25519PrivateKey> = (1u8..=3)
+        .map(|n| Ed25519PrivateKey::from_bytes(&[n; 32]).unwrap())
+        .collect();
+    let account = MultiEd25519Account::new(keys, 2).unwrap();
+
+    // Public-key bytes: pk0(32) || pk1(32) || pk2(32) || threshold(1)
+    //   = 32*3 + 1 = 97 bytes, NO length prefix (legacy MultiEd25519 wire format).
+    let pk_bytes = account.public_key().to_bytes();
+    assert_eq!(pk_bytes.len(), 32 * 3 + 1);
+    assert_eq!(
+        *pk_bytes.last().unwrap(),
+        2u8,
+        "trailing threshold byte must be 2",
+    );
+
+    // Signature bytes: sig0(64) || sig1(64) || bitmap(4)
+    //   = 64*2 + 4 = 132 bytes, NO length prefix.
+    let sig_bytes: Vec<u8> =
+        <MultiEd25519Account as Account>::sign(&account, b"fixture message").unwrap();
+    assert_eq!(sig_bytes.len(), 64 * 2 + 4);
+    let bitmap = &sig_bytes[sig_bytes.len() - 4..];
+    assert_eq!(
+        bitmap,
+        &[0xc0, 0x00, 0x00, 0x00],
+        "bitmap MSB-first: signers 0 and 1 only",
+    );
+
+    // The outer AccountAuthenticator::MultiEd25519 wraps each blob with a
+    // ULEB128 length prefix (it's a Vec<u8> from serde's perspective on
+    // this variant). Layout:
+    //   variant 1 || ULEB128(97) || pk_bytes(97) || ULEB128(132) || sig_bytes(132)
+    //   = 1 + 1 + 97 + 2 + 132 = 233 bytes (132 ULEB encodes as 2 bytes).
+    let auth = AccountAuthenticator::MultiEd25519 {
+        public_key: pk_bytes.clone(),
+        signature: sig_bytes.clone(),
+    };
+    let outer = aptos_bcs::to_bytes(&auth).unwrap();
+    let outer_hex = const_hex::encode(&outer);
+    // 233 bytes = 466 hex chars
+    assert_eq!(
+        outer.len(),
+        1 + 1 + 97 + 2 + 132,
+        "MultiEd25519 outer BCS length drifted: {outer_hex}",
+    );
+    // Variant tag 0x01 + ULEB128(97) = 0x61 -> hex prefix "0161"
+    assert!(
+        outer_hex.starts_with("0161"),
+        "MultiEd25519 variant(1) + ULEB(97) prefix drifted: {outer_hex}",
+    );
+    // ULEB128(132) = 0x84 0x01 -> starts at offset (1 + 1 + 97) * 2 = 198.
+    assert_eq!(
+        &outer_hex[198..202],
+        "8401",
+        "MultiEd25519 inner ULEB128(132) header drifted: {outer_hex}",
+    );
+}
+
+#[cfg(all(feature = "ed25519", feature = "secp256k1"))]
+#[test]
+fn account_authenticator_multi_key_bcs_layout_is_pinned() {
+    // 2-of-3 MultiKey: ed25519 + secp256k1 + ed25519 with deterministic
+    // seeds. We exercise mixed key types to verify AnyPublicKey variants
+    // are emitted with the correct discriminator bytes.
+    use aptos_sdk::account::{AnyPrivateKey, MultiKeyAccount};
+    use aptos_sdk::crypto::{Ed25519PrivateKey as EdK, Secp256k1PrivateKey};
+    let keys = vec![
+        AnyPrivateKey::ed25519(EdK::from_bytes(&[1u8; 32]).unwrap()),
+        AnyPrivateKey::secp256k1(Secp256k1PrivateKey::from_bytes(&[2u8; 32]).unwrap()),
+        AnyPrivateKey::ed25519(EdK::from_bytes(&[3u8; 32]).unwrap()),
+    ];
+    let account = MultiKeyAccount::new(keys, 2).unwrap();
+
+    // MultiKeyPublicKey BCS = ULEB128(n) || BCS(AnyPublicKey)0 || ... || threshold(1)
+    //   AnyPublicKey::Ed25519     = 0x00 || ULEB128(32) || 32B
+    //   AnyPublicKey::Secp256k1   = 0x01 || ULEB128(65) || 65B (SEC1 uncompressed)
+    //   Outer pk length = 1 (count) + 34 + 67 + 34 + 1 (threshold) = 137 bytes.
+    let pk_bytes = account.public_key().to_bytes();
+    assert_eq!(
+        pk_bytes.len(),
+        1 + (1 + 1 + 32) + (1 + 1 + 65) + (1 + 1 + 32) + 1,
+        "MultiKey public-key BCS length drifted",
+    );
+    assert_eq!(pk_bytes[0], 3u8, "leading ULEB128(3) public-key count");
+    assert_eq!(*pk_bytes.last().unwrap(), 2u8, "trailing threshold = 2");
+    // The first AnyPublicKey (Ed25519) begins immediately after the count.
+    assert_eq!(pk_bytes[1], 0x00, "first AnyPublicKey variant = Ed25519");
+    // The second AnyPublicKey (Secp256k1) begins at offset 1 + (1+1+32) = 35.
+    assert_eq!(
+        pk_bytes[35], 0x01,
+        "second AnyPublicKey variant = Secp256k1",
+    );
+
+    // MultiKeySignature BCS = ULEB128(n) || BCS(AnySignature)0 || ... ||
+    //   BitVec(4) = ULEB128(4) || 4 bytes
+    //   AnySignature::Ed25519   = 0x00 || ULEB128(64) || 64B
+    //   AnySignature::Secp256k1 = 0x01 || ULEB128(64) || 64B
+    //   For a 2-of-3 with signers at indices 0 and 1 (first two owned keys),
+    //   the bitmap is 0xc0 0x00 0x00 0x00 (MSB-first).
+    let sig_bytes: Vec<u8> =
+        <MultiKeyAccount as Account>::sign(&account, b"fixture message").unwrap();
+    let expected_sig_len = 1 + (1 + 1 + 64) + (1 + 1 + 64) + 1 + 4;
+    assert_eq!(
+        sig_bytes.len(),
+        expected_sig_len,
+        "MultiKey signature BCS length drifted",
+    );
+    assert_eq!(sig_bytes[0], 2u8, "leading ULEB128(2) signature count");
+    assert_eq!(sig_bytes[1], 0x00, "first signature variant = Ed25519");
+    // Second signature at offset 1 + (1+1+64) = 67
+    assert_eq!(sig_bytes[67], 0x01, "second signature variant = Secp256k1");
+    // BitVec at the end: ULEB128(4) || 4 bytes
+    let bitvec_offset = sig_bytes.len() - 5;
+    assert_eq!(sig_bytes[bitvec_offset], 4u8, "BitVec ULEB128(4) header");
+    assert_eq!(
+        &sig_bytes[bitvec_offset + 1..],
+        &[0xc0, 0x00, 0x00, 0x00],
+        "MultiKey bitmap MSB-first: signers 0 and 1 only",
+    );
+
+    // Outer AccountAuthenticator::MultiKey wraps each blob WITHOUT an
+    // extra length prefix (hand-rolled `serialize_account_auth_raw_pair`).
+    // Layout: variant 3 || pk_bytes || sig_bytes.
+    let auth = AccountAuthenticator::MultiKey {
+        public_key: pk_bytes.clone(),
+        signature: sig_bytes.clone(),
+    };
+    let outer = aptos_bcs::to_bytes(&auth).unwrap();
+    assert_eq!(
+        outer.len(),
+        1 + pk_bytes.len() + sig_bytes.len(),
+        "MultiKey outer length must NOT include extra ULEB prefixes",
+    );
+    assert_eq!(outer[0], 0x03, "MultiKey variant byte");
+}
+
+#[test]
 fn type_tag_nested_generic_bcs_embeds_inner_typetag() {
     let outer = TypeTag::from_str_strict("0x1::coin::Coin<0x1::aptos_coin::AptosCoin>").unwrap();
     let inner = TypeTag::aptos_coin();


### PR DESCRIPTION
## Summary

Lands four bounded follow-ups identified during the May-2026 TS-SDK parity audit. Each commit is independent and self-contained.

- **feat(mnemonic): Secp256k1 BIP-32 + custom paths** (c31fbc3) — closes a parity gap where the Rust SDK only derived Ed25519 along a hard-coded path. New `account::DerivationPath` (`from_str`, `aptos_ed25519`, `aptos_secp256k1`), `Mnemonic::derive_secp256k1_key`, plus path-explicit variants. BIP-32 implementation is cross-validated against the canonical Bitcoin reference vector (abandon × 11 about at `m/44'/0'/0'/0/0` → `e284129c…`) so hardened + non-hardened derivation are both exercised.
- **feat(api): paginate resources / modules** (71671ce) — adds `get_account_resources_paginated` / `get_account_modules_paginated` forwarding `start` / `limit` query params, matching the TS SDK. The pre-existing one-shot methods are preserved and delegate to the new variants with `None` arguments.
- **test(wire-format): pin BCS layouts** (0ac5710) — new `tests/behavioral/wire_format.rs` pins the on-wire byte shape of `RawTransaction` (sequenced and orderless prefixes), `AccountAuthenticator::Ed25519`, `AccountAuthenticator::SingleKey(Ed25519)`, and a nested-generic `TypeTag`. Inputs are fully deterministic so a TS-SDK fixture comparison can be added without network access. Notably asserts that `SingleKey`'s `Vec<u8>` fields are emitted inline (no outer ULEB length prefix) — a derive-based regression would silently break on-chain auth.
- **feat(api): scaffold api/ans.rs to match AGENTS.md** (bdb8ff9) — AGENTS.md had documented `api/ans.rs` but the file did not exist. This commit lands an honest skeleton (`lookup`, `reverse_lookup`) that returns `AptosError::Internal("not yet implemented")` so callers fail fast; AGENTS.md updated to mark the module as scaffold.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p aptos-sdk --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p aptos-sdk --all-targets -- -D warnings`
- [x] `cargo clippy -p aptos-sdk --no-default-features -- -D warnings`
- [x] `cargo test -p aptos-sdk --all-features` — 959 lib + 57 integration + 32 doc tests, 0 failures
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc -p aptos-sdk --all-features --no-deps`
- [ ] Cross-validate the new wire-format fixtures against the TypeScript SDK with the same deterministic inputs (`[1u8;32]` Ed25519 key, expiration `9_999_999_999`, recipient `0x2`, amount `1_000_000`) — recommended before publishing the next SDK version

## Out of scope
- AIP-122 account abstraction, high-level DigitalAsset / FungibleAsset helpers — flagged in the audit as roadmap items, not regressions.
- A real ANS implementation (this PR ships the scaffold only; design needs network-pinned contract addresses).