### PR TITLE
chore: release aptos-sdk v0.5.0 and aptos-sdk-macros v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-sdk"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aptos-bcs",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-sdk-macros"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aptos-sdk",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,8 @@ large_futures = "allow"
 [workspace.dependencies]
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
-aptos-sdk = { version = "0.4.1", path = "crates/aptos-sdk" }
-aptos-sdk-macros = { version = "0.2.1", path = "crates/aptos-sdk-macros" }
+aptos-sdk = { version = "0.5.0", path = "crates/aptos-sdk" }
+aptos-sdk-macros = { version = "0.3.0", path = "crates/aptos-sdk-macros" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.

--- a/crates/aptos-sdk-macros/CHANGELOG.md
+++ b/crates/aptos-sdk-macros/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.3.0] - 2026-05-21
+
+### Changed
+- **MSRV bumped from 1.90 to 1.95** (via workspace `rust-version`). Aligns
+  with `aptos-sdk` 0.5.0; downstream consumers need at least Rust 1.95.0
+  (released 2026-04-14).
+
 ## [0.2.1] - 2026-03-04
 
 ### Changed
@@ -33,5 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for entry functions, view functions, and struct definitions
 - Move-to-Rust type mapping (primitives, vectors, options, objects)
 
+[0.3.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/macros-v0.3.0
+[0.2.1]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/macros-v0.2.1
 [0.2.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/macros-v0.2.0
 [0.1.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/macros-v0.1.0

--- a/crates/aptos-sdk-macros/Cargo.toml
+++ b/crates/aptos-sdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos-sdk-macros"
-version = "0.2.1"
+version = "0.3.0"
 description = "Procedural macros for type-safe Aptos contract bindings"
 authors.workspace = true
 edition = "2024"

--- a/crates/aptos-sdk/CHANGELOG.md
+++ b/crates/aptos-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.5.0] - 2026-05-21
+
 ### Added
 - `api::AnsClient` scaffold (`api/ans.rs`) -- exposes `lookup(name)` and
   `reverse_lookup(address)` method signatures so future ANS work has an
@@ -331,5 +333,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This SDK is independent of `aptos-core` for faster compilation
 - Minimum Supported Rust Version (MSRV): 1.90
 
+[0.5.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/sdk-v0.5.0
+[0.4.1]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/sdk-v0.4.1
 [0.4.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/sdk-v0.4.0
 [0.1.0]: https://github.com/aptos-labs/aptos-rust-sdk/releases/tag/sdk-v0.1.0

--- a/crates/aptos-sdk/Cargo.toml
+++ b/crates/aptos-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos-sdk"
-version = "0.4.1"
+version = "0.5.0"
 description = "A user-friendly, idiomatic Rust SDK for the Aptos blockchain"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## Summary

- Bumps `aptos-sdk` from `0.4.1` → `0.5.0`
- Bumps `aptos-sdk-macros` from `0.2.1` → `0.3.0`
- Promotes `## [unreleased]` sections in both changelogs to their release versions
- Adds footer reference links for the new versions

## Highlights of what's in 0.5.0

See [`crates/aptos-sdk/CHANGELOG.md`](crates/aptos-sdk/CHANGELOG.md) for the full list. Notable items:

**Breaking / MSRV**
- MSRV bumped 1.90 → 1.95 (released 2026-04-14)
- Resolver upgraded v2 → v3

**New API surface**
- `AnsClient` scaffold (`lookup` / `reverse_lookup`)
- Paginated `get_account_resources_paginated` / `get_account_modules_paginated`
- `DerivationPath` / `PathComponent` BIP-32/44 builders
- `Mnemonic::derive_secp256k1_key` + `_at_path` variants
- `WebAuthnAccount` for on-chain secp256r1 signing
- Simulation improvements (`simulate_with_options`, multi-agent, fee-payer)
- `for_simulate_endpoint` helpers on `SignedTransaction` / authenticators

**Bug fixes (on-wire correctness)**
- BCS wire format for `AccountAuthenticator::{SingleKey, MultiKey, Keyless}`
- `Secp256k1PrivateKey::sign` no longer double-hashes (was SHA-256², now SHA-3-256)
- MSB-first signer bitmaps in `MultiEd25519Signature` and `MultiKeySignature`
- `Secp256k1PublicKey::to_address` / `Secp256r1PublicKey::to_address` now use SEC1 uncompressed encoding
- Script payload BCS variant ordering

**Deprecated**
- `Secp256r1Account` for on-chain signing (use `WebAuthnAccount` instead)

## Publishing checklist

After this PR merges:
- [ ] Push `macros-v0.3.0` tag → triggers crates.io publish for macros
- [ ] Push `sdk-v0.5.0` tag → triggers crates.io publish for SDK (waits for macros to be indexed first)
- [ ] Confirm GitHub Releases created by the `release-notes` workflow job

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p aptos-sdk --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy -p aptos-sdk --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p aptos-sdk --no-default-features -- -D warnings` — clean
- [x] `cargo test -p aptos-sdk --all-features` — 971 tests pass
- [x] `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc -p aptos-sdk --all-features --no-deps` — clean